### PR TITLE
Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,65 @@ vim.notify("This is an error message.\nSomething went wrong!", "error", {
 
 ## Configuration
 
-TODO!
+You can set options by calling the `require("notify.config")setup()`. Here's an example of the default config:
+
+```lua
+require("notify.config").setup({
+  -- Default level and default icon (must exist, name or integer)
+  default_level = "info",
+
+  -- Definition of each level (type of notification)
+  levels = {
+    -- Note: the default list matches vim.lsp.log_levels
+
+    [0] = {  -- An integer, alternative to 'name'
+      name = "trace",  -- minimal required field
+      icon = "✎",
+      border = {fg = "#848482"},  -- border highlight group
+      title = {fg = "#797979"}  -- title hightligth group
+    },
+    [1] = {
+      name = "debug",
+      icon = "",
+      border = {fg = "#008B8B"},
+      title = {fg = "#008B8B"}
+    },
+    [2] = {
+      name = "info",
+      icon = "",
+      border = {fg = "#6699CC"},
+      title = {fg = "#6699CC"}
+    },
+    [3] = {
+      name = "warn",
+      icon = "",
+      border = {fg = "#B6A642"},
+      title = {fg = "#B5A642"}
+    },
+    [4] = {
+      name = "error",
+      icon = "",
+      border = {fg = "#7A1F1F"},
+      title = {fg = "#CC0000"}
+    }
+  }
+})
+```
+
+If you want to add new notification themes (that do not necessarily match a log
+level), you can just add a new entry (be careful not to overwrite existing
+numbers):
+```lua
+config.setup({
+  levels = {
+    [#config.levels()] = {  -- If your levels are 1 indexed, use '+ 1' here
+      name = "white",
+      -- No 'icon =', this will use the default icon
+      border = {fg = "#FFFFFF"},
+      title = {fg = "#FFFFFF"}
+    }
+  }
+})
+
+vim.notify("This notification is entirely white", "white")
+```

--- a/lua/notify/config/highlights.lua
+++ b/lua/notify/config/highlights.lua
@@ -1,10 +1,40 @@
-vim.cmd("hi default NotifyERROR guifg=#8A1F1F")
-vim.cmd("hi default NotifyWARN guifg=#79491D")
-vim.cmd("hi default NotifyINFO guifg=#4F6752")
-vim.cmd("hi default NotifyDEBUG guifg=#8B8B8B")
-vim.cmd("hi default NotifyTRACE guifg=#4F3552")
-vim.cmd("hi default NotifyERRORTitle guifg=#F70067")
-vim.cmd("hi default NotifyWARNTitle guifg=#F79000")
-vim.cmd("hi default NotifyINFOTitle guifg=#A9FF68")
-vim.cmd("hi default NotifyDEBUGTitle guifg=#8B8B8B")
-vim.cmd("hi default NotifyTRACETitle guifg=#D484FF")
+local M = {}
+
+M.groups = {'border', 'title'}
+
+-- Example of levels:
+-- {
+--   [0] = {  -- An integer, alternative to 'name'
+--     name = "trace",  -- minimal required field
+--     icon = "✎",
+--     border = {fg = "#7A1F1F"},  -- border highlight group
+--     title = {fg = "#CC0000"}  -- title hightligth group
+--   }
+-- }
+function M.setup(levels, default)
+  -- If 'default' is set, we set the lighlight as overwritable
+  default = default or false
+
+  -- Example of an expected command:
+  -- "hi default NotifyTRACETitle guifg=#D484FF"
+  for level, config in pairs(levels) do
+    for _, group in pairs(M.groups) do
+      -- The command starts by 'hi default? Notify' ..
+      local hlcommand = "hi " .. (default and "default" or "") .. " Notify"
+
+      -- Then the level, to upper (ERROR, TRACE, ...)
+      hlcommand = hlcommand .. string.upper(config.name)
+
+      -- Then we add the group, capitalized (Border, Title)
+      hlcommand = hlcommand .. (group:gsub("^%l", string.upper))
+
+      -- Then we add 'guibg=..', 'guifg=..' if they're given
+      for key, val in pairs(config[group]) do
+          hlcommand = string.format("%s gui%s=%s", hlcommand, key, val)
+      end
+      vim.cmd(hlcommand)
+    end
+  end
+end
+
+return M

--- a/lua/notify/config/init.lua
+++ b/lua/notify/config/init.lua
@@ -1,27 +1,116 @@
 local M = {}
 
-require("notify.config.highlights")
+local highlight = require("notify.config.highlights")
 
+-- Configuration section
 local default_config = {
-  icons = {
-    ERROR = "",
-    WARN = "",
-    INFO = "",
-    DEBUG = "",
-    TRACE = "✎",
-  },
-}
+  -- Default level and default icon (must exist, name or integer)
+  default_level = "info",
 
+  -- Definition of each level (type of notification)
+  levels = {
+    -- Note: the default list matches vim.lsp.log_levels
+
+    [0] = {  -- An integer, alternative to 'name'
+      name = "trace",  -- minimal required field
+      icon = "✎",
+      border = {fg = "#848482"},  -- border highlight group
+      title = {fg = "#797979"}  -- title hightligth group
+    },
+    [1] = {
+      name = "debug",
+      icon = "",
+      border = {fg = "#008B8B"},
+      title = {fg = "#008B8B"}
+    },
+    [2] = {
+      name = "info",
+      icon = "",
+      border = {fg = "#6699CC"},
+      title = {fg = "#6699CC"}
+    },
+    [3] = {
+      name = "warn",
+      icon = "",
+      border = {fg = "#B6A642"},
+      title = {fg = "#B5A642"}
+    },
+    [4] = {
+      name = "error",
+      icon = "",
+      border = {fg = "#7A1F1F"},
+      title = {fg = "#CC0000"}
+    }
+  }
+}
+-- Set the default highlights
+highlight.setup(default_config.levels, true)
+
+
+local function validate_level(level, level_config)
+  -- Validate top level keys
+  vim.validate({
+    level={level, 'number'},
+    name={level_config.name, 'string'},
+    icon={level_config.icon, 'string', true},
+    border={level_config.border, 'table', true},
+    title={level_config.title, 'table', true}
+  })
+
+  -- Validate the highlight groups
+  for _, hgroup in pairs(highlight.groups) do
+    local group = level_config[hgroup]
+    if group ~= nil then
+      -- So far we only support fg & bg
+      vim.validate({
+          fg={group.fg, 'string', true},
+          bg={group.fg, 'string', true},
+      })
+    end
+  end
+end
+
+-- Start with user_config as default. Built it when config.setup() is called
 local user_config = default_config
 
 function M.setup(config)
-  local filled = vim.tbl_deep_extend("keep", config or {}, default_config)
+  -- tbl extend does not work properly with integers maps (see neovim/#15382)
+  local filled = vim.tbl_deep_extend("keep", config or {}, user_config)
+  -- it does work when the integer keys are n=on the main level though
+  filled.levels = vim.tbl_deep_extend("keep", config.levels or {}, user_config.levels)
+  --print(vim.inspect(filled))
+
+  -- Check the consistency of the new user config
+  for level, level_config in pairs(filled.levels) do
+    validate_level(level, level_config)
+    -- We want to set the default as a number for faster access
+    if level == filled.default_level or
+        level_config.name == filled.default_level then
+        filled.default_level_number = level
+    end
+  end
+
+  -- Revert the change if the default is invalid
+  if filled.default_level_number == nil then
+    print("Provided default ("..filled.default_level..") is invalid")
+    return
+  end
+
+  -- Set the changes if everything seems alright
   user_config = filled
+
+  -- Set highlights
+  highlight.setup(user_config.levels, false)
   require("dapui.config.highlights").setup()
 end
 
-function M.icons()
-  return user_config.icons
+function M.default_level()
+  -- If we're not using the defaults, default_level_number exists
+  return user_config.default_level_number or 2
+end
+
+function M.levels()
+  return user_config.levels
 end
 
 return M

--- a/lua/notify/init.lua
+++ b/lua/notify/init.lua
@@ -7,8 +7,8 @@ local running = false
 
 local function run()
   running = true
-  local succees, ran = pcall(renderer.step, renderer, 30 / 1000)
-  if not succees then
+  local success, ran = pcall(renderer.step, renderer, 30 / 1000)
+  if not success then
     print("Error running notification service: " .. ran)
     running = false
     return

--- a/lua/notify/init.lua
+++ b/lua/notify/init.lua
@@ -1,5 +1,6 @@
 local NotificationRenderer = require("notify.render")
 local config = require("notify.config")
+local util = require("notify.util")
 
 local renderer = NotificationRenderer()
 
@@ -23,7 +24,8 @@ end
 local notifications = {}
 
 ---@class Notification
----@field level string
+---@field level number
+---@field level_name string
 ---@field message string
 ---@field timeout number
 ---@field title string
@@ -35,20 +37,20 @@ local notifications = {}
 local Notification = {}
 
 function Notification:new(message, level, opts)
-  if type(level) == "number" then
-    level = vim.lsp.log_levels[level]
-  end
   if type(message) == "string" then
     message = vim.split(message, "\n")
   end
-  level = vim.fn.toupper(level or "info")
+  -- Convert level names to number (or default)
+  level = util.to_level(level)
   local notif = {
     message = message,
     title = opts.title or "",
-    icon = opts.icon or config.icons()[level] or config.icons().INFO,
+    icon = opts.icon or config.levels()[level].icon or 
+        config.levels()[config.default_level()].icon,
     time = vim.fn.localtime(),
     timeout = opts.timeout or 5000,
     level = level,
+    level_name = string.upper(config.levels()[level].name),
     on_open = opts.on_open,
     on_close = opts.on_close,
   }

--- a/lua/notify/render.lua
+++ b/lua/notify/render.lua
@@ -1,6 +1,7 @@
 local api = vim.api
 local namespace = api.nvim_create_namespace("nvim-notify")
 local animate = require("notify.animate")
+local config = require("notify.config")
 local util = require("notify.util")
 
 local WinStage = {
@@ -239,9 +240,15 @@ function NotificationRenderer:add_window(notif, row)
     local title_line = left_title
       .. string.rep(" ", win_width - vim.fn.strchars(left_title .. right_title))
       .. right_title
-    vim.api.nvim_buf_set_lines(buf, 0, 1, false, { title_line, string.rep("━", win_width) })
-    vim.api.nvim_buf_add_highlight(buf, namespace, "Notify" .. notif.level .. "Title", 0, 0, -1)
-    vim.api.nvim_buf_add_highlight(buf, namespace, "Notify" .. notif.level, 1, 0, -1)
+    vim.api.nvim_buf_set_lines(buf, 0, 1, false, {
+        title_line, string.rep("━", win_width)
+    })
+    vim.api.nvim_buf_add_highlight(
+        buf, namespace, "Notify" .. notif.level_name .. "Title", 0, 0, -1
+    )
+    vim.api.nvim_buf_add_highlight(
+        buf, namespace, "Notify" .. notif.level_name .. "Border", 1, 0, -1
+    )
   end
   vim.api.nvim_buf_set_lines(buf, message_line, message_line + #notif.message, false, notif.message)
   vim.api.nvim_buf_set_option(buf, "modifiable", false)
@@ -258,7 +265,7 @@ function NotificationRenderer:add_window(notif, row)
   }
 
   local win = vim.api.nvim_open_win(buf, false, win_opts)
-  vim.wo[win].winhl = "Normal:Normal,FloatBorder:Notify" .. notif.level
+  vim.wo[win].winhl = "Normal:Normal,FloatBorder:Notify"..notif.level_name.."Border"
   vim.wo[win].wrap = false
 
   self.win_stages[win] = WinStage.OPENING

--- a/lua/notify/util/init.lua
+++ b/lua/notify/util/init.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local config = require("notify.config")
+
 function M.round(num, decimals)
   if decimals then
     return tonumber(string.format("%." .. decimals .. "f", num))
@@ -35,6 +37,17 @@ function M.set_win_config(win, conf)
     conf[field] = math.max(M.round(conf[field]), 1)
   end
   return (pcall(vim.api.nvim_win_set_config, win, conf))
+end
+
+-- Converts a level name (or number) to a level number.
+-- returns the default number on invalid input
+function M.to_level(level_name)
+  for level, level_config in pairs(config.levels()) do
+    if level == level_name or level_config.name == level_name then
+      return level
+    end
+  end
+  return config.default_level()
 end
 
 M.FIFOQueue = require("notify.util.queue")


### PR DESCRIPTION
This is a pretty big set of changes. My goal in this PR was to address the @TODO for the README.md section of configuration.

While going over the code to figure that out, I realised that the configuration (as it is) is pretty static. We can change icons, and changing the highlight groups is done using vim `hi` commands. The default levels are `vim.lsp.log_levels`, which are 0 indexed.

This PR offers (configuration wise) the following improvements:
- one main table to hold every important configuration element
- allow complete control over `level number` vs. `level name` equivalence
- allow to add more levels (mainly to have more sets of notifications)

Implementation wise, the following things changed:
- prepare for (eventually) more control over colors (right now: title & border)
- split level (numbers) and level_name (string, upper case) for clarity
- configurable default level, in a single place