### PR TITLE
Enable fade effects to work on transparent backgrounds by fixing "bad argument to blend" bug

### DIFF
--- a/lua/notify/service/buffer/highlights.lua
+++ b/lua/notify/service/buffer/highlights.lua
@@ -55,7 +55,7 @@ function NotifyBufHighlights:set_opacity(alpha)
   for group, fields in pairs(self.groups) do
     local updated_fields = {}
     for name, value in pairs(fields) do
-      if value ~= "" then
+      if value ~= "" and value ~= "none" then
         updated_fields[name] = util.blend(value, background, alpha / 100)
       end
     end


### PR DESCRIPTION
I'm one of the troublemakers with a transparent background, the new updates with the fade effects were causing a bug for me:
`
Error running notification service: ...art/nvim-notify/lua/notify/service/buffer/highlights.lua:59: bad argument #2 to
'blend' (no value)
`

Just required an extra conditional to see if the background color ends up at 'none' or ''.  In case you're wondering, it still fades even though my background is transparent because I have active tmux panes highlighted a solid color to help identify the active pane, so when it's focused it's actually opaque (even though the vim background never is).

