### PR TITLE
fix: allow for lazy loading telescope with notify

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ or in lua
 require('telescope').extensions.notify.notify(<opts>)
 ```
 
+**Note:** If you lazy load `telescope` you should manually call `require("telescope").load_extension("notify")` before using the above commands. If you don't lazy load `telescope` then `notify` does this for you.
+
 <p align="center">
   <img src="https://user-images.githubusercontent.com/24252670/136264308-2fcdfe57-a8f6-4b34-8ea1-e3a8349bc581.png" />
 </p>

--- a/lua/notify/init.lua
+++ b/lua/notify/init.lua
@@ -18,7 +18,7 @@ local M = {}
 function M.setup(user_config)
   config.setup(user_config)
 
-  local has_telescope = pcall(require, "telescope")
+  local has_telescope = (vim.fn.exists("g:loaded_telescope") == 1)
   if has_telescope then
     require("telescope").load_extension("notify")
   end


### PR DESCRIPTION
Some users may only load telescope when `require("telescope")` is first executed (using packer's `module` key), so avoid doing this in notify setup otherwise loading notify will also load telescope.

Also recommend `:Telescope notify notify` rather than `:Telescope notify` since the former will work even if telescope is loaded after notify and `require("telescope").load_extension("notify")` hasn't been run.

Edit: Forgot to mention that `g:loaded_telescope` is defined here
https://github.com/nvim-telescope/telescope.nvim/blob/3f45d64e9c47ad9eef273ddab65790a84cced30b/plugin/telescope.vim#L6-L9