### PR TITLE
feat: refresh timeout on replace

### DIFF
--- a/lua/notify/service/buffer/init.lua
+++ b/lua/notify/service/buffer/init.lua
@@ -11,6 +11,7 @@ local NotifyBufHighlights = require("notify.service.buffer.highlights")
 ---@field _height number
 ---@field _width number
 ---@field _max_width number | nil
+---@field _was_replaced boolean
 local NotificationBuf = {}
 
 local BufState = {
@@ -25,6 +26,7 @@ function NotificationBuf:new(kwargs)
     _state = BufState.CLOSED,
     _width = 0,
     _height = 0,
+    _was_replaced = false,
   }
   setmetatable(notif_buf, self)
   self.__index = self
@@ -33,6 +35,7 @@ function NotificationBuf:new(kwargs)
 end
 
 function NotificationBuf:set_notification(notif)
+  self._was_replaced = nil ~= self._notif
   self._notif = notif
   self:_create_highlights()
 end
@@ -85,6 +88,10 @@ function NotificationBuf:width()
 end
 
 function NotificationBuf:should_stay()
+  if self._was_replaced then
+    self._was_replaced = false
+    return true
+  end
   if self._notif.keep then
     return self._notif.keep()
   end


### PR DESCRIPTION
Hi,

Frist, thanks for the amazing job!

Then, onto business: this is a proposal to refresh the timeout when replacing an existing notification.
The use case I faced was that I wanted to create a mapping to cycle through some colorschemes and apply them. When applying a colorscheme I want to add a notification with its name.

The issue is better explained with a timeline, the current behavior is:
| elapsed time (s) | action |
| - | - |
| 0 | `id = vim.notify('test 1', vim.log.levels.INFO, { timeout = 4000})` |
| 1 | Notification "test 1" visible |
| 2 | `id = vim.notify('test 2', nil, { replace = id })` |
| 3 | Notification "test 2" visible |
| 4 | Notification "test 2" closing |

While I expected:
| elapsed time (s) | action |
| - | - |
| 0 | `id = vim.notify('test 1', vim.log.levels.INFO, { timeout = 4000})` |
| 1 | Notification "test 1" visible |
| 2 | `id = vim.notify('test 2', nil, { replace = id })` |
| 3 | Notification "test 2" visible |
| 4 | Notification "test 2" visible |
| 5 | Notification "test 2" visible |
| 6 | Notification "test 2" closing |

The proposed solution works, at least in my case, I don't know how to write a reliable test though...
I'm not sure about the approach neither.