### PR TITLE
feat: handle replacing closed notification

### DIFF
--- a/lua/notify/init.lua
+++ b/lua/notify/init.lua
@@ -102,24 +102,24 @@ function notify.notify(message, level, opts)
       opts.replace = opts.replace.id
     end
     local existing = notifications[opts.replace]
-    if not existing then
-      vim.notify("Invalid notification to replace", "error", { title = "nvim-notify" })
-      return
-    end
-    local notif_keys = {
-      "title",
-      "icon",
-      "timeout",
-      "keep",
-      "on_open",
-      "on_close",
-      "render",
-      "hide_from_history",
-    }
-    message = message or existing.message
-    level = level or existing.level
-    for _, key in ipairs(notif_keys) do
-      opts[key] = opts[key] or existing[key]
+    if not existing or service:find(opts.replace):is_closed() then
+      opts.replace = nil
+    else
+      local notif_keys = {
+        "title",
+        "icon",
+        "timeout",
+        "keep",
+        "on_open",
+        "on_close",
+        "render",
+        "hide_from_history",
+      }
+      message = message or existing.message
+      level = level or existing.level
+      for _, key in ipairs(notif_keys) do
+        opts[key] = opts[key] or existing[key]
+      end
     end
   end
   opts.render = get_render(opts.render or config.render())

--- a/lua/notify/service/buffer/init.lua
+++ b/lua/notify/service/buffer/init.lua
@@ -147,6 +147,11 @@ function NotificationBuf:level()
   return self._notif.level
 end
 
+---@return boolean
+function NotificationBuf:is_closed()
+  return BufState.CLOSED == self._state
+end
+
 ---@param buf number
 ---@param notification Notification
 ---@return NotificationBuf

--- a/lua/notify/service/init.lua
+++ b/lua/notify/service/init.lua
@@ -53,7 +53,7 @@ end
 
 ---@return NotificationBuf
 function NotificationService:replace(id, notif)
-  local existing = self._buffers[id]
+  local existing = self:find(id)
   if not existing then
     vim.notify("No matching notification found to replace")
     return
@@ -63,6 +63,11 @@ function NotificationService:replace(id, notif)
   self._buffers[notif.id] = existing
   existing:render()
   return existing
+end
+
+---@return NotificationBuf | nil
+function NotificationService:find(id)
+  return self._buffers[id]
 end
 
 function NotificationService:dismiss(opts)


### PR DESCRIPTION
Hi again,

There is an issue when sending an id for a closed notification, instead of having an error notification `Invalid notification to replace` there is the following error:
```
E5108: Error executing lua ...ker/start/nvim-notify/lua/notify/service/buffer/init.lua:99: Invalid buffer id: 4
stack traceback:
        [C]: in function 'nvim_buf_set_option'
        ...ker/start/nvim-notify/lua/notify/service/buffer/init.lua:99: in function 'render'
        ...ack/packer/start/nvim-notify/lua/notify/service/init.lua:64: in function 'replace'
        ...m/site/pack/packer/start/nvim-notify/lua/notify/init.lua:131: in function 'notify'
        [string ":lua"]:1: in main chunk
```

And if we try again with the same ID:
```
E5108: Error executing lua ...m/site/pack/packer/start/nvim-notify/lua/notify/init.lua:132: attempt to index local 'notif_buf' (a nil value)
stack traceback:
        ...m/site/pack/packer/start/nvim-notify/lua/notify/init.lua:132: in function 'notify'
        [string ":lua"]:1: in main chunk
```

Instead of the original error message and those errors I propose to simply create a new notification if we can't do the replacement.

I think it will make the plugin more easy to use in a generic way.
Let's imagine we have a function that notifies about something, this function can be called multiple time. Potentially it can even be called before the previous notification was closed (for instance the user defined a long timeout or whatever).
The only way to deal with that is to:
```lua
local notification_id
function doSomething()
  notification_id = require('notify').notify('message to replace if possible', vim.log.level.INFO, {
    on_close = function()
      notification_id = nil
    end,
  })
end
```

Currently I play with the idea of leveraging [freedesktop notification's specification](https://github.com/camilledejoye/notifier.nvim) to see if it's possible to reliably use `vim.notify` as a generic port without knowing which adapter is used.  
In such a situation it's not possible to use the `on_close` trick.