### PR TITLE
fix(history): add space between icon and message

### DIFF
--- a/lua/notify/init.lua
+++ b/lua/notify/init.lua
@@ -136,7 +136,7 @@ function notify._print_history()
       { notif.title[1], "NotifyLogTitle" },
       { #notif.title[1] > 0 and " " or "", "MsgArea" },
       { notif.icon, "Notify" .. notif.level .. "Title" },
-      { #notif.title[1] > 0 and " " or "", "MsgArea" },
+      { " ", "MsgArea" },
       { notif.level, "Notify" .. notif.level .. "Title" },
       { " ", "MsgArea" },
       { table.concat(notif.message, "\n"), "MsgArea" },


### PR DESCRIPTION
<img width="576" alt="image" src="https://user-images.githubusercontent.com/60088301/172109294-047e1f92-77ef-483f-a0ce-405701b5d2ac.png">

Really tiny fix.
I found `notify._print_history()` function removes space between icon and message if the notification doesn't have a title.
Remove useless conditional statement `#notif.title[1] > 0`

<img width="577" alt="image" src="https://user-images.githubusercontent.com/60088301/172109952-d6216003-87a0-40d6-a82f-0aa5fa680997.png">