### PR TITLE
Telescope notify – Avoid nil error when nothing is selected

### DIFF
--- a/lua/telescope/_extensions/notify.lua
+++ b/lua/telescope/_extensions/notify.lua
@@ -64,6 +64,10 @@ local telescope_notifications = function(opts)
         actions.select_default:replace(function()
           actions.close(prompt_bufnr)
           local selection = action_state.get_selected_entry()
+          if selection == nil then
+            return
+          end
+
           local notification = selection.value
           local buf = vim.api.nvim_create_buf(false, true)
           local notif_buf = NotificationBuf(buf, notification, { config = notify._config() })


### PR DESCRIPTION
Fixes: when no notification selected, either due empty notification history or filter removing all valid selection, a nil error occurred.

```
E5108: Error executing lua ...r/start/nvim-notify/lua/telescope/_extensions/notify.lua:67: attempt to index local 'selection' (a nil value)
stack traceback:
        ...r/start/nvim-notify/lua/telescope/_extensions/notify.lua:67: in function 'run_replace_or_original'
        ...packer/start/telescope.nvim/lua/telescope/actions/mt.lua:65: in function 'key_func'
        ...k/packer/start/telescope.nvim/lua/telescope/mappings.lua:338: in function 'execute_keymap'
        [string ":lua"]:1: in main chunk
Press ENTER or type command to continue
```