### PR TITLE
Notifications are no longer focusable

### DIFF
--- a/lua/notify/windows/init.lua
+++ b/lua/notify/windows/init.lua
@@ -58,6 +58,7 @@ function WindowAnimator:push_pending(queue)
       notif_buf.highlights:set_opacity(opacity)
     end
     win_opts.noautocmd = true
+    win_opts.focusable = false
     local win = util.open_win(notif_buf, false, win_opts)
     self.win_stages[win] = 2
     self.win_states[win] = {}


### PR DESCRIPTION
This PR fixes an issue in which the cursor could be positioned into the floating notification window. This at the minimum should be an option if not default

Example of the problem here. https://i.ibb.co/LQRNNcc/ezgif-5-20a85d0c5e.gif