### PR TITLE
feat(config): allow setting a default direction

### DIFF
--- a/doc/nvim-notify.txt
+++ b/doc/nvim-notify.txt
@@ -1,5 +1,5 @@
 ================================================================================
-                                                                   *nvim-notify*
+NVIM-NOTIFY                                                        *nvim-notify*
 
 A fancy, configurable notification manager for NeoVim
 
@@ -74,6 +74,7 @@ notify.setup({user_config})                                   *notify.setup()*
     Default values:
       {
         background_colour = "Normal",
+        direction = "top_down",
         fps = 30,
         icons = {
           DEBUG = "",
@@ -177,7 +178,7 @@ notify.instance({user_config}, {inherit})                  *notify.instance()*
 
 
 ================================================================================
-                                                                 *notify.config*
+CONFIG                                                           *notify.config*
 
 notify.Config                                                  *notify.Config*
 
@@ -220,7 +221,7 @@ notify.Config                                                  *notify.Config*
 
 
 ================================================================================
-                                                               *notify-render()*
+NOTIFY-RENDER()                                                *notify-render()*
 
 Notification buffer rendering
 

--- a/doc/nvim-notify.txt
+++ b/doc/nvim-notify.txt
@@ -74,7 +74,6 @@ notify.setup({user_config})                                   *notify.setup()*
     Default values:
       {
         background_colour = "Normal",
-        direction = "top_down",
         fps = 30,
         icons = {
           DEBUG = "",
@@ -87,7 +86,8 @@ notify.setup({user_config})                                   *notify.setup()*
         minimum_width = 50,
         render = "default",
         stages = "fade_in_slide_out",
-        timeout = 5000
+        timeout = 5000,
+        top_down = true
       }
 
     Parameters: ~
@@ -217,6 +217,9 @@ notify.Config                                                  *notify.Config*
                                                  animation stages, higher
                                                  value means smoother
                                                  animations but more CPU usage
+        {top_down}          (boolean)            whether or not to position
+                                                 the notifications at the top
+                                                 or not
 
 
 

--- a/lua/notify/config/init.lua
+++ b/lua/notify/config/init.lua
@@ -2,6 +2,7 @@
 
 local Config = {}
 local util = require("notify.util")
+local stage_util = require("notify.stages.util")
 
 require("notify.config.highlights")
 
@@ -29,6 +30,7 @@ local default_config = {
   on_close = nil,
   minimum_width = 50,
   fps = 30,
+  direction = stage_util.DIRECTION.TOP_DOWN,
   icons = {
     ERROR = "",
     WARN = "",
@@ -139,6 +141,10 @@ function Config.setup(custom_config)
 
   function config.on_open()
     return user_config.on_open
+  end
+
+  function config.direction()
+    return user_config.direction
   end
 
   function config.on_close()

--- a/lua/notify/config/init.lua
+++ b/lua/notify/config/init.lua
@@ -2,7 +2,6 @@
 
 local Config = {}
 local util = require("notify.util")
-local stage_util = require("notify.stages.util")
 
 require("notify.config.highlights")
 
@@ -30,7 +29,7 @@ local default_config = {
   on_close = nil,
   minimum_width = 50,
   fps = 30,
-  direction = stage_util.DIRECTION.TOP_DOWN,
+  top_down = true,
   icons = {
     ERROR = "",
     WARN = "",
@@ -53,6 +52,7 @@ local default_config = {
 ---@field render function | string: Function to render a notification buffer or a built-in renderer name
 ---@field minimum_width integer: Minimum width for notification windows
 ---@field fps integer: Frames per second for animation stages, higher value means smoother animations but more CPU usage
+---@field top_down boolean: whether or not to position the notifications at the top or not
 
 local opacity_warned = false
 
@@ -143,8 +143,8 @@ function Config.setup(custom_config)
     return user_config.on_open
   end
 
-  function config.direction()
-    return user_config.direction
+  function config.top_down()
+    return user_config.top_down
   end
 
   function config.on_close()

--- a/lua/notify/init.lua
+++ b/lua/notify/init.lua
@@ -158,7 +158,9 @@ function notify.instance(user_config, inherit)
   local instance_config = config.setup(user_config)
 
   local animator_stages = instance_config.stages()
-  animator_stages = type(animator_stages) == "string" and stages[animator_stages] or animator_stages
+  animator_stages = type(animator_stages) == "string"
+      and stages[animator_stages](instance_config.direction())
+    or animator_stages
   local animator = WindowAnimator(animator_stages, instance_config)
   local service = NotificationService(instance_config, animator)
 

--- a/lua/notify/init.lua
+++ b/lua/notify/init.lua
@@ -9,6 +9,7 @@ local stages = require("notify.stages")
 local Notification = require("notify.service.notification")
 local WindowAnimator = require("notify.windows")
 local NotificationService = require("notify.service")
+local stage_util = require("notify.stages.util")
 
 ---@type Notification[]
 local notifications = {}
@@ -158,8 +159,10 @@ function notify.instance(user_config, inherit)
   local instance_config = config.setup(user_config)
 
   local animator_stages = instance_config.stages()
-  animator_stages = type(animator_stages) == "string"
-      and stages[animator_stages](instance_config.direction())
+  local direction = instance_config.top_down() and stage_util.DIRECTION.TOP_DOWN
+    or stage_util.DIRECTION.BOTTOM_UP
+
+  animator_stages = type(animator_stages) == "string" and stages[animator_stages](direction)
     or animator_stages
   local animator = WindowAnimator(animator_stages, instance_config)
   local service = NotificationService(instance_config, animator)

--- a/lua/notify/stages/fade.lua
+++ b/lua/notify/stages/fade.lua
@@ -1,47 +1,48 @@
 local stages_util = require("notify.stages.util")
 
-return {
-  function(state)
-    local next_height = state.message.height + 2
-    local next_row =
-      stages_util.available_slot(state.open_windows, next_height, stages_util.DIRECTION.TOP_DOWN)
-    if not next_row then
-      return nil
-    end
-    return {
-      relative = "editor",
-      anchor = "NE",
-      width = state.message.width,
-      height = state.message.height,
-      col = vim.opt.columns:get(),
-      row = next_row,
-      border = "rounded",
-      style = "minimal",
-      opacity = 0,
-    }
-  end,
-  function()
-    return {
-      opacity = { 100 },
-      col = { vim.opt.columns:get() },
-    }
-  end,
-  function()
-    return {
-      col = { vim.opt.columns:get() },
-      time = true,
-    }
-  end,
-  function()
-    return {
-      opacity = {
-        0,
-        frequency = 2,
-        complete = function(cur_opacity)
-          return cur_opacity <= 4
-        end,
-      },
-      col = { vim.opt.columns:get() },
-    }
-  end,
-}
+return function(direction)
+  return {
+    function(state)
+      local next_height = state.message.height + 2
+      local next_row = stages_util.available_slot(state.open_windows, next_height, direction)
+      if not next_row then
+        return nil
+      end
+      return {
+        relative = "editor",
+        anchor = "NE",
+        width = state.message.width,
+        height = state.message.height,
+        col = vim.opt.columns:get(),
+        row = next_row,
+        border = "rounded",
+        style = "minimal",
+        opacity = 0,
+      }
+    end,
+    function()
+      return {
+        opacity = { 100 },
+        col = { vim.opt.columns:get() },
+      }
+    end,
+    function()
+      return {
+        col = { vim.opt.columns:get() },
+        time = true,
+      }
+    end,
+    function()
+      return {
+        opacity = {
+          0,
+          frequency = 2,
+          complete = function(cur_opacity)
+            return cur_opacity <= 4
+          end,
+        },
+        col = { vim.opt.columns:get() },
+      }
+    end,
+  }
+end

--- a/lua/notify/stages/fade_in_slide_out.lua
+++ b/lua/notify/stages/fade_in_slide_out.lua
@@ -1,76 +1,77 @@
 local stages_util = require("notify.stages.util")
 
-return {
-  function(state)
-    local next_height = state.message.height + 2
-    local next_row =
-      stages_util.available_slot(state.open_windows, next_height, stages_util.DIRECTION.TOP_DOWN)
-    if not next_row then
-      return nil
-    end
-    return {
-      relative = "editor",
-      anchor = "NE",
-      width = state.message.width,
-      height = state.message.height,
-      col = vim.opt.columns:get(),
-      row = next_row,
-      border = "rounded",
-      style = "minimal",
-      opacity = 0,
-    }
-  end,
-  function(state, win)
-    return {
-      opacity = { 100 },
-      col = { vim.opt.columns:get() },
-      row = {
-        stages_util.slot_after_previous(win, state.open_windows, stages_util.DIRECTION.TOP_DOWN),
-        frequency = 3,
-        complete = function()
-          return true
-        end,
-      },
-    }
-  end,
-  function(state, win)
-    return {
-      col = { vim.opt.columns:get() },
-      time = true,
-      row = {
-        stages_util.slot_after_previous(win, state.open_windows, stages_util.DIRECTION.TOP_DOWN),
-        frequency = 3,
-        complete = function()
-          return true
-        end,
-      },
-    }
-  end,
-  function(state, win)
-    return {
-      width = {
-        1,
-        frequency = 2.5,
-        damping = 0.9,
-        complete = function(cur_width)
-          return cur_width < 3
-        end,
-      },
-      opacity = {
-        0,
-        frequency = 2,
-        complete = function(cur_opacity)
-          return cur_opacity <= 4
-        end,
-      },
-      col = { vim.opt.columns:get() },
-      row = {
-        stages_util.slot_after_previous(win, state.open_windows, stages_util.DIRECTION.TOP_DOWN),
-        frequency = 3,
-        complete = function()
-          return true
-        end,
-      },
-    }
-  end,
-}
+return function(direction)
+  return {
+    function(state)
+      local next_height = state.message.height + 2
+      local next_row = stages_util.available_slot(state.open_windows, next_height, direction)
+      if not next_row then
+        return nil
+      end
+      return {
+        relative = "editor",
+        anchor = "NE",
+        width = state.message.width,
+        height = state.message.height,
+        col = vim.opt.columns:get(),
+        row = next_row,
+        border = "rounded",
+        style = "minimal",
+        opacity = 0,
+      }
+    end,
+    function(state, win)
+      return {
+        opacity = { 100 },
+        col = { vim.opt.columns:get() },
+        row = {
+          stages_util.slot_after_previous(win, state.open_windows, direction),
+          frequency = 3,
+          complete = function()
+            return true
+          end,
+        },
+      }
+    end,
+    function(state, win)
+      return {
+        col = { vim.opt.columns:get() },
+        time = true,
+        row = {
+          stages_util.slot_after_previous(win, state.open_windows, direction),
+          frequency = 3,
+          complete = function()
+            return true
+          end,
+        },
+      }
+    end,
+    function(state, win)
+      return {
+        width = {
+          1,
+          frequency = 2.5,
+          damping = 0.9,
+          complete = function(cur_width)
+            return cur_width < 3
+          end,
+        },
+        opacity = {
+          0,
+          frequency = 2,
+          complete = function(cur_opacity)
+            return cur_opacity <= 4
+          end,
+        },
+        col = { vim.opt.columns:get() },
+        row = {
+          stages_util.slot_after_previous(win, state.open_windows, direction),
+          frequency = 3,
+          complete = function()
+            return true
+          end,
+        },
+      }
+    end,
+  }
+end

--- a/lua/notify/stages/init.lua
+++ b/lua/notify/stages/init.lua
@@ -13,7 +13,7 @@ local M = {}
 setmetatable(M, {
   ---@return Stages
   __index = function(_, key)
-    return vim.deepcopy(require("notify.stages." .. key))
+    return require("notify.stages." .. key)
   end,
 })
 

--- a/lua/notify/stages/slide.lua
+++ b/lua/notify/stages/slide.lua
@@ -1,47 +1,48 @@
 local stages_util = require("notify.stages.util")
 
-return {
-  function(state)
-    local next_height = state.message.height + 2
-    local next_row =
-      stages_util.available_slot(state.open_windows, next_height, stages_util.DIRECTION.TOP_DOWN)
-    if not next_row then
-      return nil
-    end
-    return {
-      relative = "editor",
-      anchor = "NE",
-      width = 1,
-      height = state.message.height,
-      col = vim.opt.columns:get(),
-      row = next_row,
-      border = "rounded",
-      style = "minimal",
-    }
-  end,
-  function(state)
-    return {
-      width = { state.message.width, frequency = 2 },
-      col = { vim.opt.columns:get() },
-    }
-  end,
-  function()
-    return {
-      col = { vim.opt.columns:get() },
-      time = true,
-    }
-  end,
-  function()
-    return {
-      width = {
-        1,
-        frequency = 2.5,
-        damping = 0.9,
-        complete = function(cur_width)
-          return cur_width < 2
-        end,
-      },
-      col = { vim.opt.columns:get() },
-    }
-  end,
-}
+return function(direction)
+  return {
+    function(state)
+      local next_height = state.message.height + 2
+      local next_row = stages_util.available_slot(state.open_windows, next_height, direction)
+      if not next_row then
+        return nil
+      end
+      return {
+        relative = "editor",
+        anchor = "NE",
+        width = 1,
+        height = state.message.height,
+        col = vim.opt.columns:get(),
+        row = next_row,
+        border = "rounded",
+        style = "minimal",
+      }
+    end,
+    function(state)
+      return {
+        width = { state.message.width, frequency = 2 },
+        col = { vim.opt.columns:get() },
+      }
+    end,
+    function()
+      return {
+        col = { vim.opt.columns:get() },
+        time = true,
+      }
+    end,
+    function()
+      return {
+        width = {
+          1,
+          frequency = 2.5,
+          damping = 0.9,
+          complete = function(cur_width)
+            return cur_width < 2
+          end,
+        },
+        col = { vim.opt.columns:get() },
+      }
+    end,
+  }
+end

--- a/lua/notify/stages/static.lua
+++ b/lua/notify/stages/static.lua
@@ -1,28 +1,29 @@
 local stages_util = require("notify.stages.util")
 
-return {
-  function(state)
-    local next_height = state.message.height + 2
-    local next_row =
-      stages_util.available_slot(state.open_windows, next_height, stages_util.DIRECTION.TOP_DOWN)
-    if not next_row then
-      return nil
-    end
-    return {
-      relative = "editor",
-      anchor = "NE",
-      width = state.message.width,
-      height = state.message.height,
-      col = vim.opt.columns:get(),
-      row = next_row,
-      border = "rounded",
-      style = "minimal",
-    }
-  end,
-  function()
-    return {
-      col = { vim.opt.columns:get() },
-      time = true,
-    }
-  end,
-}
+return function(direction)
+  return {
+    function(state)
+      local next_height = state.message.height + 2
+      local next_row = stages_util.available_slot(state.open_windows, next_height, direction)
+      if not next_row then
+        return nil
+      end
+      return {
+        relative = "editor",
+        anchor = "NE",
+        width = state.message.width,
+        height = state.message.height,
+        col = vim.opt.columns:get(),
+        row = next_row,
+        border = "rounded",
+        style = "minimal",
+      }
+    end,
+    function()
+      return {
+        col = { vim.opt.columns:get() },
+        time = true,
+      }
+    end,
+  }
+end


### PR DESCRIPTION
This allows setting `config.direction` and refactors each stage to be a function which takes the direction as an argument. The direction from the config is then passed to the style that is set.

Not sure what your thoughts are re. this approach @rcarriga, if it seems alright to you then I'll add some docs for it