### PR TITLE
added simple render style

### DIFF
--- a/lua/notify/render/simple.lua
+++ b/lua/notify/render/simple.lua
@@ -1,0 +1,44 @@
+local api = vim.api
+local base = require("notify.render.base")
+
+return function(bufnr, notif, highlights, config)
+  local max_message_width = math.max(math.max(unpack(vim.tbl_map(function(line)
+    return vim.fn.strchars(line)
+  end, notif.message))))
+  local title = notif.title[1]
+  local title_accum = vim.str_utfindex(title)
+
+  local title_buffer = string.rep(" ", (math.max(max_message_width, title_accum, config.minimum_width()) - title_accum)/2)
+
+  local namespace = base.namespace()
+
+  api.nvim_buf_set_lines(bufnr, 0, 1, false, { "", "" })
+  api.nvim_buf_set_extmark(bufnr, namespace, 0, 0, {
+    virt_text = {
+      { title_buffer..title..title_buffer, highlights.title },
+    },
+    virt_text_win_col = 0,
+    priority = 10,
+  })
+  api.nvim_buf_set_extmark(bufnr, namespace, 1, 0, {
+    virt_text = {
+      {
+        string.rep(
+          "━",
+		  math.max(max_message_width, title_accum, config.minimum_width())
+        ),
+        highlights.border,
+      },
+    },
+    virt_text_win_col = 0,
+    priority = 10,
+  })
+  api.nvim_buf_set_lines(bufnr, 2, -1, false, notif.message)
+
+  api.nvim_buf_set_extmark(bufnr, namespace, 2, 0, {
+    hl_group = highlights.body,
+    end_line = 1 + #notif.message,
+    end_col = #notif.message[#notif.message],
+    priority = 50,
+  })
+end


### PR DESCRIPTION
I would like to propose a simple render style in between "default" and "minimal", namely only showing (centred) title (with no icons and timestamps) and notification message: see rendering examples in the screenshots below

<img width="1302" alt="Screenshot 2022-09-21 at 11 45 43" src="https://user-images.githubusercontent.com/15387611/191474548-375043e1-7dcf-474d-87c3-bc3647ef9d31.png">

<img width="520" alt="Screenshot 2022-09-21 at 11 52 05" src="https://user-images.githubusercontent.com/15387611/191474559-5f044786-50fa-434d-9c19-a47712ad46db.png">


I have tweaked the original `default.lua` to centre the title and remove the spurious spaces, it should work fine with all use cases (but perhaps there are cases I have not considered - I am just slowly familiarising with the code): what do you think?