### PR TITLE
notification message wrap at max_width when wrap_message is set true

### DIFF
--- a/lua/notify/config/init.lua
+++ b/lua/notify/config/init.lua
@@ -37,6 +37,7 @@ local default_config = {
     DEBUG = "",
     TRACE = "✎",
   },
+  wrap_message = false,
 }
 
 ---@class notify.Config
@@ -53,6 +54,7 @@ local default_config = {
 ---@field minimum_width integer: Minimum width for notification windows
 ---@field fps integer: Frames per second for animation stages, higher value means smoother animations but more CPU usage
 ---@field top_down boolean: whether or not to position the notifications at the top or not
+---@field wrap_message boolean: whether or not to wrap the message at max_width
 
 local opacity_warned = false
 

--- a/lua/notify/init.lua
+++ b/lua/notify/init.lua
@@ -10,6 +10,7 @@ local Notification = require("notify.service.notification")
 local WindowAnimator = require("notify.windows")
 local NotificationService = require("notify.service")
 local stage_util = require("notify.stages.util")
+local util = require("notify.util")
 
 ---@type Notification[]
 local notifications = {}
@@ -81,6 +82,11 @@ function notify.notify(message, level, opts)
   if not global_instance then
     notify.setup()
   end
+
+  if global_config.wrap_message == true then
+    return global_instance.notify(util.wrap_message(message, global_config.max_width), level, opts)
+  end
+
   return global_instance.notify(message, level, opts)
 end
 
@@ -99,6 +105,11 @@ function notify.async(message, level, opts)
   if not global_instance then
     notify.setup()
   end
+
+  if global_config.wrap_message == true then
+    return global_instance.notify(util.wrap_message(message, global_config.max_width), level, opts)
+  end
+
   return global_instance.async(message, level, opts)
 end
 

--- a/lua/notify/util/init.lua
+++ b/lua/notify/util/init.lua
@@ -127,4 +127,8 @@ local function split_string(string, size)
   return lines
 end
 
+function M.wrap_message(message, size)
+  return split_string(message, size)
+end
+
 return M

--- a/lua/notify/util/init.lua
+++ b/lua/notify/util/init.lua
@@ -117,4 +117,14 @@ function M.highlight(name, fields)
   end
 end
 
+local function split_string(string, size)
+  local lines = {}
+
+  for i = 1, #string, size do
+    lines[#lines + 1] = string:sub(i, i + size - 1)
+  end
+
+  return lines
+end
+
 return M


### PR DESCRIPTION
Hello

I missed a parameter to wrap messages at the `max_width` for messages.

The reason for such a parameter would be to wrap messages that a from `vim.notify`<br> when it is overwritten with `require ("notify")`.

Long story short i implemented the parameter `wrap_message`.
```lua

notify.setup {
  wrap_message = true,
  max_width = 80,
}
```

When the parameter `wrap_message` is set to true and passed into the notify setup, messages are split at a string length of `max_width`.