### PR TITLE
fix: make notify work when wiping all buffers with %bw

### DIFF
--- a/lua/notify/service/buffer/init.lua
+++ b/lua/notify/service/buffer/init.lua
@@ -140,6 +140,10 @@ function NotificationBuf:buffer()
   return self._buffer
 end
 
+function NotificationBuf:is_valid()
+  return self._buffer and vim.api.nvim_buf_is_valid(self._buffer)
+end
+
 function NotificationBuf:level()
   return self._notif.level
 end

--- a/lua/notify/service/init.lua
+++ b/lua/notify/service/init.lua
@@ -66,7 +66,7 @@ end
 
 function NotificationService:replace(id, notif)
   local existing = self._buffers[id]
-  if not existing then
+  if not (existing and existing:is_valid()) then
     vim.notify("No matching notification found to replace")
     return
   end


### PR DESCRIPTION
Some Noice users like to do `%bw` to wipe all buffers (which they shouldn't do, but anyway). This leads to issues in Noice, Nui and Notify.

I've just fixed them all in each project.

Fixes:
- [ ] https://github.com/folke/noice.nvim/issues/292
- [ ] https://github.com/folke/noice.nvim/issues/95
- [ ] https://github.com/folke/noice.nvim/issues/244