### PR TITLE
feat: luarocks support

### DIFF
--- a/.github/workflows/luarocks.yaml
+++ b/.github/workflows/luarocks.yaml
@@ -1,18 +1,24 @@
 name: "release"
 on:
+  release:
+    types:
+      - created
   push:
     tags:
       - '*'
+  workflow_dispatch: # Allow manual trigger
+  pull_request: # Tests the luarocks installation without releasing on PR
 jobs:
   luarocks-upload:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - name: Get Version 
+        # tags do not trigger the workflow when they are created by other workflows or releases
+        run: echo "LUAROCKS_VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v3
+        uses: nvim-neorocks/luarocks-tag-release@v5
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         with:
-          labels: |
-            neovim
-            plugin
+          version: ${{ env.LUAROCKS_VERSION }}

--- a/.github/workflows/luarocks.yaml
+++ b/.github/workflows/luarocks.yaml
@@ -1,0 +1,20 @@
+name: "release"
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v1.0.2
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          copy_directories: |
+            doc
+          labels: |
+            neovim
+            plugin

--- a/.github/workflows/luarocks.yaml
+++ b/.github/workflows/luarocks.yaml
@@ -9,12 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v1.0.2
+        uses: nvim-neorocks/luarocks-tag-release@v3
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         with:
-          copy_directories: |
-            doc
           labels: |
             neovim
             plugin

--- a/nvim-notify-scm-1.rockspec
+++ b/nvim-notify-scm-1.rockspec
@@ -8,6 +8,7 @@ description = {
    labels = {
      'neovim',
      'plugin'
+     'nvim'
    },
    homepage = 'http://github.com/rcarriga/nvim-notify',
    license = 'MIT',
@@ -18,7 +19,7 @@ dependencies = {
 }
 
 source = {
-   url = 'git://github.com/nvim-notify',
+   url = 'git://github.com/rcarriga/nvim-notify',
 }
 
 build = {

--- a/nvim-notify-scm-1.rockspec
+++ b/nvim-notify-scm-1.rockspec
@@ -1,0 +1,29 @@
+local _MODREV, _SPECREV = 'scm', '-1'
+rockspec_format = "3.0"
+package = 'nvim-notify'
+version = _MODREV .. _SPECREV
+
+description = {
+   summary = 'A fancy, configurable, notification manager for NeoVim ',
+   labels = {
+     'neovim',
+     'plugin'
+   },
+   homepage = 'http://github.com/rcarriga/nvim-notify',
+   license = 'MIT',
+}
+
+dependencies = {
+   'lua >= 5.1',
+}
+
+source = {
+   url = 'git://github.com/nvim-notify',
+}
+
+build = {
+   type = 'builtin',
+   copy_directories = {
+     'doc'
+   },
+}


### PR DESCRIPTION
Hey :wave: 

### Summary

This PR is part of a push to get neovim plugins on [LuaRocks](https://luarocks.org/labels/neovim).

* See [this blog post](https://mrcjkb.github.io/posts/2023-01-10-luarocks-tag-release.html), which follows up on [a series of posts](https://teto.github.io/posts/2021-09-17-neovim-plugin-luarocks.html) by @teto.
* See also: [rocks.nvim](https://github.com/nvim-neorocks/rocks.nvim), a new luarocks-based plugin manager.

### Things done:

* Add a workflow that publishes tags to LuaRocks when a tag or release is pushed.
* This is based on the approach implemented for neotest, which should work with the existing semantic release workflow.

### Notes:

* Tagged releases are installed locally and then published to luarocks.org.
  On PRs, a test release is installed, but not published.
* For the luarocks workflow to work, someone with a luarocks.org account will have to add their [API key](https://luarocks.org/settings/api-keys) to this repo's [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
* Due to a shortcoming in LuaRocks (https://github.com/luarocks/luarocks-site/issues/188), the `neovim` (and other) labels have to be added  to the LuaRocks package manually (after the first upload), for this plugin to show up in https://luarocks.org/labels/neovim.