### PR TITLE
docs: add vimdoc initial line

### DIFF
--- a/doc/nvim-notify.txt
+++ b/doc/nvim-notify.txt
@@ -1,3 +1,4 @@
+*nvim-notify.txt*  A fancy, configurable notification manager for NeoVim
 ================================================================================
 NVIM-NOTIFY                                                        *nvim-notify*
 


### PR DESCRIPTION
In order to have proper addition to **LOCAL ADDITIONS:**, this initial line needs to be added.
