### PR TITLE
Correct type of direction variable. It M.DIRECTION values are strings.

### DIFF
--- a/lua/notify/stages/util.lua
+++ b/lua/notify/stages/util.lua
@@ -61,7 +61,7 @@ local function border_padding(direction, win_conf)
 end
 
 ---@param windows number[]
----@param direction integer
+---@param direction string
 ---@return { max: integer, min: integer}[]
 local function window_intervals(windows, direction, cmp)
   local win_intervals = {}
@@ -104,7 +104,7 @@ end
 
 ---@param existing_wins number[] Windows to avoid overlapping
 ---@param required_space number Window height or width including borders
----@param direction integer Direction to stack windows, one of M.DIRECTION
+---@param direction string Direction to stack windows, one of M.DIRECTION
 ---@return number | nil Slot to place window at or nil if no slot available
 function M.available_slot(existing_wins, required_space, direction)
   local increasing = is_increasing(direction)


### PR DESCRIPTION
Minor documentation corrections:

`M.DIRECTION` values are all strings, Lua LSP detected the type error while the values in function calls were correct. Example:

In

```lua
local next_row = stages_util.available_slot(state.open_windows, next_height, stages_util.DIRECTION.BOTTOM_UP)
````

`stages_util.DIRECTION.BOTTOM_UP` is a string, and is the correct value that should be used here. But since the `available_slot` method was expecting an integer, LSP complained (even though the code still works since lua is dynamically typed).

Same with `window_intervals` method.