### PR TITLE
bugfix(rendering): hide `:` if the title is missing in the `compact` renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ See `:help notify-render()` for details
 
 ![default](https://user-images.githubusercontent.com/24252670/141534868-fdcc9d03-9f7b-47fd-acfc-5a20b98e4e0a.png)
 
-2. "minimal
+2. "minimal"
 
 ![image](https://user-images.githubusercontent.com/24252670/141534952-bb0cf491-5bb4-473c-9a67-8adb5b23b232.png)
 

--- a/lua/notify/render/compact.lua
+++ b/lua/notify/render/compact.lua
@@ -5,7 +5,12 @@ return function(bufnr, notif, highlights)
   local icon = notif.icon
   local title = notif.title[1]
 
-  local prefix = string.format("%s | %s:", icon, title)
+  local prefix
+  if type(title) == "string" and #title > 0 then
+    prefix = string.format("%s | %s:", icon, title)
+  else
+    prefix = string.format("%s |", icon)
+  end
   notif.message[1] = string.format("%s %s", prefix, notif.message[1])
 
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, notif.message)


### PR DESCRIPTION
As of now there is a colon before the message even if there's no title before it, so this PR removes the colon only if there's no title in the message config