### PR TITLE
feat: allow custom time format

### DIFF
--- a/lua/notify/config/init.lua
+++ b/lua/notify/config/init.lua
@@ -30,6 +30,10 @@ local default_config = {
   minimum_width = 50,
   fps = 30,
   top_down = true,
+  time_formats = {
+    notification_history = "%FT%T",
+    notification = "%T",
+  },
   icons = {
     ERROR = "",
     WARN = "",
@@ -47,6 +51,7 @@ local default_config = {
 ---@field stages string|function[] Animation stages
 ---@field background_colour string For stages that change opacity this is treated as the highlight behind the window. Set this to either a highlight group, an RGB hex value e.g. "#000000" or a function returning an RGB code for dynamic values
 ---@field icons table Icons for each level (upper case names)
+---@field time_formats table Time formats for different kind of notifications
 ---@field on_open function Function called when a new window is opened, use for changing win settings/config
 ---@field on_close function Function called when a window is closed
 ---@field render function|string Function to render a notification buffer or a built-in renderer name
@@ -125,6 +130,10 @@ function Config.setup(custom_config)
 
   function config.background_colour()
     return tonumber(user_config.background_colour():gsub("#", "0x"), 16)
+  end
+
+  function config.time_formats()
+    return user_config.time_formats
   end
 
   function config.icons()

--- a/lua/notify/init.lua
+++ b/lua/notify/init.lua
@@ -159,7 +159,10 @@ function notify._print_history()
   end
   for _, notif in ipairs(global_instance.history()) do
     vim.api.nvim_echo({
-      { vim.fn.strftime("%FT%T", notif.time), "NotifyLogTime" },
+      {
+        vim.fn.strftime(notify._config().time_formats().notification_history, notif.time),
+        "NotifyLogTime",
+      },
       { " ", "MsgArea" },
       { notif.title[1], "NotifyLogTitle" },
       { #notif.title[1] > 0 and " " or "", "MsgArea" },

--- a/lua/notify/service/notification.lua
+++ b/lua/notify/service/notification.lua
@@ -29,7 +29,7 @@ function Notification:new(id, message, level, opts, config)
   local time = vim.fn.localtime()
   local title = opts.title or ""
   if type(title) == "string" then
-    title = { title, vim.fn.strftime("%H:%M", time) }
+    title = { title, vim.fn.strftime(config.time_formats().notification, time) }
   end
   vim.validate({
     message = { message, "table" },

--- a/lua/telescope/_extensions/notify.lua
+++ b/lua/telescope/_extensions/notify.lua
@@ -27,6 +27,7 @@ local displayer = entry_display.create({
 })
 
 local telescope_notifications = function(opts)
+  local time_format = require("notify")._config().time_formats().notification
   local notifs = require("notify").history()
   local reversed = {}
   for i, notif in ipairs(notifs) do
@@ -43,7 +44,7 @@ local telescope_notifications = function(opts)
             value = notif,
             display = function(entry)
               return displayer({
-                { vim.fn.strftime("%T", entry.value.time), "NotifyLogTime" },
+                { vim.fn.strftime(time_format, entry.value.time), "NotifyLogTime" },
                 { entry.value.title[1], "NotifyLogTitle" },
                 { entry.value.icon, "Notify" .. entry.value.level .. "Title" },
                 { entry.value.level, "Notify" .. entry.value.level .. "Title" },


### PR DESCRIPTION
Allow the time format for the notification history & the notifications themselves to be customized.

Handy for those who don't do 24h clocks.

I did consolidate 2 formats:

https://github.com/rcarriga/nvim-notify/pull/214/files#diff-cc0264adaefdad4a3e145a4ad44a0c98f186d24da90e022e9215f3ef68fa828bL32
and
https://github.com/rcarriga/nvim-notify/pull/214/files#diff-3eb94df4dcd115e2877155af0a02b9cee18d96cc0b1ff3a908459b63fd6948cdL46

Since `%T` is `%H:%M:%S` I imagined that the fact that they differ wasn't intentional. Let me know if you want me to separate them.