### PR TITLE
feat: new renderer `wrapped-compact`

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,12 @@ See `:help notify-render()` for details
 
 ![image](https://user-images.githubusercontent.com/24252670/212632432-86621888-f885-4074-aed4-d12b5e291ab2.png)
 
+5. "wrapped-compact"
+
+Mostly same as `compact`, but lines are wrapped based on `max_width`, some padding is added.
+
+![image](https://github.com/rcarriga/nvim-notify/assets/73286100/72237d45-6e3b-4c2a-8010-513a26871682)
+
 Feel free to submit custom rendering functions to share with others!
 
 ### Animation Style

--- a/doc/nvim-notify.txt
+++ b/doc/nvim-notify.txt
@@ -208,6 +208,7 @@ Built-in renderers:
 - `"default"`
 - `"minimal"`
 - `"simple"`
+- `"wrapped-compact"`
 
 Custom functions should accept a buffer, a notification record and a highlights table
 

--- a/lua/notify/render/wrapped-compact.lua
+++ b/lua/notify/render/wrapped-compact.lua
@@ -58,7 +58,7 @@ return function (bufnr, notif, highlights, config)
 		table.insert(notif.message, 1, prefix)
 	else
 		-- no title = prefix the icon
-		prefix = string.format(" %s ", icon)
+		prefix = string.format(" %s", icon)
 		notif.message[1] = string.format("%s %s", prefix, notif.message[1])
 	end
 

--- a/lua/notify/render/wrapped-compact.lua
+++ b/lua/notify/render/wrapped-compact.lua
@@ -1,6 +1,6 @@
 -- alternative compact renderer for nvim-notify. 
--- Wraps text and adds some padding. (only really to the left, since padding to
--- the right is somehow not display correctly?)
+-- Wraps text and adds some padding (only really to the left, since padding to
+-- the right is somehow not display correctly).
 -- Modified version of https://github.com/rcarriga/nvim-notify/blob/master/lua/notify/render/compact.lua
 --------------------------------------------------------------------------------
 
@@ -20,39 +20,38 @@ end
 ---@param lines string[]
 ---@param max_width number
 ---@return string[]
-local function customWrap(lines, max_width)
-	local wrappedLines = {}
+local function custom_wrap(lines, max_width)
+	local wrapped_lines = {}
 	for _, line in pairs(lines) do
 		local new_lines = split_length(line, max_width)
 		for _, nl in ipairs(new_lines) do
 			nl = nl:gsub("^%s*", " "):gsub("%s*$", " ") -- ensure padding
-			table.insert(wrappedLines, nl)
+			table.insert(wrapped_lines, nl)
 		end
 	end
-	return wrappedLines
+	return wrapped_lines
 end
 
 ---@param bufnr number
 ---@param notif object
 ---@param highlights object
----@param config object plugin configObj
+---@param config object plugin config_obj
 return function (bufnr, notif, highlights, config)
-	local base = require("notify.render.base")
-	local namespace = base.namespace()
+	local namespace = require("notify.render.base").namespace()
 	local icon = notif.icon
 	local title = notif.title[1]
 	local prefix
 
 	-- wrap the text & add spacing
 	local max_width = config.max_width()
-	notif.message = customWrap(notif.message, max_width)
+	notif.message = custom_wrap(notif.message, max_width)
 
-	local defaultTitles = { "Error", "Warning", "Notify" }
-	local hasValidManualTitle = type(title) == "string"
+	local default_titles = { "Error", "Warning", "Notify" }
+	local has_valid_manual_title = type(title) == "string"
 		and #title > 0
-		and not vim.tbl_contains(defaultTitles, title)
+		and not vim.tbl_contains(default_titles, title)
 
-	if hasValidManualTitle then
+	if has_valid_manual_title then
 		-- has title = icon + title as header row
 		prefix = string.format(" %s %s", icon, title)
 		table.insert(notif.message, 1, prefix)

--- a/lua/notify/render/wrapped-compact.lua
+++ b/lua/notify/render/wrapped-compact.lua
@@ -1,0 +1,86 @@
+-- alternative compact renderer for nvim-notify. 
+-- Wraps text and adds some padding. (only really to the left, since padding to
+-- the right is somehow not display correctly?)
+-- Modified version of https://github.com/rcarriga/nvim-notify/blob/master/lua/notify/render/compact.lua
+--------------------------------------------------------------------------------
+
+---@param line string
+---@param width number
+---@return string[]
+local function split_length(line, width)
+	local text = {}
+	local next_line
+	while true do
+		if #line == 0 then return text end
+		next_line, line = line:sub(1, width), line:sub(width)
+		text[#text + 1] = next_line
+	end
+end
+
+---@param lines string[]
+---@param max_width number
+---@return string[]
+local function customWrap(lines, max_width)
+	local wrappedLines = {}
+	for _, line in pairs(lines) do
+		local new_lines = split_length(line, max_width)
+		for _, nl in ipairs(new_lines) do
+			nl = nl:gsub("^%s*", " "):gsub("%s*$", " ") -- ensure padding
+			table.insert(wrappedLines, nl)
+		end
+	end
+	return wrappedLines
+end
+
+---@param bufnr number
+---@param notif object
+---@param highlights object
+---@param config object plugin configObj
+return function (bufnr, notif, highlights, config)
+	local base = require("notify.render.base")
+	local namespace = base.namespace()
+	local icon = notif.icon
+	local title = notif.title[1]
+	local prefix
+
+	-- wrap the text & add spacing
+	local max_width = config.max_width()
+	notif.message = customWrap(notif.message, max_width)
+
+	local defaultTitles = { "Error", "Warning", "Notify" }
+	local hasValidManualTitle = type(title) == "string"
+		and #title > 0
+		and not vim.tbl_contains(defaultTitles, title)
+
+	if hasValidManualTitle then
+		-- has title = icon + title as header row
+		prefix = string.format(" %s %s", icon, title)
+		table.insert(notif.message, 1, prefix)
+	else
+		-- no title = prefix the icon
+		prefix = string.format(" %s ", icon)
+		notif.message[1] = string.format("%s %s", prefix, notif.message[1])
+	end
+
+	vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, notif.message)
+
+	local icon_length = vim.str_utfindex(icon)
+	local prefix_length = vim.str_utfindex(prefix) + 1
+
+	vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, 0, {
+		hl_group = highlights.icon,
+		end_col = icon_length + 1,
+		priority = 50,
+	})
+	vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, icon_length + 1, {
+		hl_group = highlights.title,
+		end_col = prefix_length + 1,
+		priority = 50,
+	})
+	vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, prefix_length + 1, {
+		hl_group = highlights.body,
+		end_line = #notif.message,
+		priority = 50,
+	})
+end
+

--- a/lua/notify/render/wrapped-compact.lua
+++ b/lua/notify/render/wrapped-compact.lua
@@ -1,4 +1,4 @@
--- alternative compact renderer for nvim-notify. 
+-- alternative compact renderer for nvim-notify.
 -- Wraps text and adds some padding (only really to the left, since padding to
 -- the right is somehow not display correctly).
 -- Modified version of https://github.com/rcarriga/nvim-notify/blob/master/lua/notify/render/compact.lua
@@ -8,78 +8,79 @@
 ---@param width number
 ---@return string[]
 local function split_length(line, width)
-	local text = {}
-	local next_line
-	while true do
-		if #line == 0 then return text end
-		next_line, line = line:sub(1, width), line:sub(width)
-		text[#text + 1] = next_line
-	end
+  local text = {}
+  local next_line
+  while true do
+    if #line == 0 then
+      return text
+    end
+    next_line, line = line:sub(1, width), line:sub(width)
+    text[#text + 1] = next_line
+  end
 end
 
 ---@param lines string[]
 ---@param max_width number
 ---@return string[]
 local function custom_wrap(lines, max_width)
-	local wrapped_lines = {}
-	for _, line in pairs(lines) do
-		local new_lines = split_length(line, max_width)
-		for _, nl in ipairs(new_lines) do
-			nl = nl:gsub("^%s*", " "):gsub("%s*$", " ") -- ensure padding
-			table.insert(wrapped_lines, nl)
-		end
-	end
-	return wrapped_lines
+  local wrapped_lines = {}
+  for _, line in pairs(lines) do
+    local new_lines = split_length(line, max_width)
+    for _, nl in ipairs(new_lines) do
+      nl = nl:gsub("^%s*", " "):gsub("%s*$", " ") -- ensure padding
+      table.insert(wrapped_lines, nl)
+    end
+  end
+  return wrapped_lines
 end
 
 ---@param bufnr number
 ---@param notif object
 ---@param highlights object
 ---@param config object plugin config_obj
-return function (bufnr, notif, highlights, config)
-	local namespace = require("notify.render.base").namespace()
-	local icon = notif.icon
-	local title = notif.title[1]
-	local prefix
+return function(bufnr, notif, highlights, config)
+  local namespace = require("notify.render.base").namespace()
+  local icon = notif.icon
+  local title = notif.title[1]
+  local prefix
 
-	-- wrap the text & add spacing
-	local max_width = config.max_width()
-	notif.message = custom_wrap(notif.message, max_width)
+  -- wrap the text & add spacing
+  local max_width = config.max_width()
+  notif.message = custom_wrap(notif.message, max_width)
 
-	local default_titles = { "Error", "Warning", "Notify" }
-	local has_valid_manual_title = type(title) == "string"
-		and #title > 0
-		and not vim.tbl_contains(default_titles, title)
+  local default_titles = { "Error", "Warning", "Notify" }
+  local has_valid_manual_title = type(title) == "string"
+    and #title > 0
+    and not vim.tbl_contains(default_titles, title)
 
-	if has_valid_manual_title then
-		-- has title = icon + title as header row
-		prefix = string.format(" %s %s", icon, title)
-		table.insert(notif.message, 1, prefix)
-	else
-		-- no title = prefix the icon
-		prefix = string.format(" %s", icon)
-		notif.message[1] = string.format("%s %s", prefix, notif.message[1])
-	end
+  if has_valid_manual_title then
+    -- has title = icon + title as header row
+    prefix = string.format(" %s %s", icon, title)
+    table.insert(notif.message, 1, prefix)
+  else
+    -- no title = prefix the icon
+    prefix = string.format(" %s", icon)
+    notif.message[1] = string.format("%s %s", prefix, notif.message[1])
+  end
 
-	vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, notif.message)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, notif.message)
 
-	local icon_length = vim.str_utfindex(icon)
-	local prefix_length = vim.str_utfindex(prefix) + 1
+  local icon_length = vim.str_utfindex(icon)
+  local prefix_length = vim.str_utfindex(prefix) + 1
 
-	vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, 0, {
-		hl_group = highlights.icon,
-		end_col = icon_length + 1,
-		priority = 50,
-	})
-	vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, icon_length + 1, {
-		hl_group = highlights.title,
-		end_col = prefix_length + 1,
-		priority = 50,
-	})
-	vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, prefix_length + 1, {
-		hl_group = highlights.body,
-		end_line = #notif.message,
-		priority = 50,
-	})
+  vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, 0, {
+    hl_group = highlights.icon,
+    end_col = icon_length + 1,
+    priority = 50,
+  })
+  vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, icon_length + 1, {
+    hl_group = highlights.title,
+    end_col = prefix_length + 1,
+    priority = 50,
+  })
+  vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, prefix_length + 1, {
+    hl_group = highlights.body,
+    end_line = #notif.message,
+    priority = 50,
+  })
 end
-


### PR DESCRIPTION
This is an alternative to the `compact` renderer, with the following modifications:
- it adds wrapping, a feature requested numerous times (#137 #88 #143 #129)
- it simulates padding (by prepending a space on every line 🙈). (#152)
- handles the title in a more sensitive manner: if there is a manual title, it becomes a header line, if there is no title given, just prepend the icon.

here is an example with `max_width = 40` for the following notification call

```lua
vim.notify("Hello World. Lorem ipsum dolor sit amet qui minim labore adipisicing minim sint cillum sint consectetur cupidatat.", vim.log.levels.INFO, {title = "My Plugin"})
```

<img width="648" alt="Pasted image 2023-09-04 at 12 20 27@2x" src="https://github.com/rcarriga/nvim-notify/assets/73286100/72237d45-6e3b-4c2a-8010-513a26871682">

