### PR TITLE
fix: do not defer notify when nvim is running in a headless mode

### DIFF
--- a/lua/notify/init.lua
+++ b/lua/notify/init.lua
@@ -3,6 +3,7 @@
 
 local config = require("notify.config")
 local instance = require("notify.instance")
+local headless = (#vim.api.nvim_list_uis() == 0)
 
 ---@class notify
 local notify = {}
@@ -186,7 +187,7 @@ end
 
 setmetatable(notify, {
   __call = function(_, m, l, o)
-    if vim.in_fast_event() or vim.fn.has("vim_starting") == 1 then
+    if vim.in_fast_event() or (not headless and vim.fn.has("vim_starting") == 1) then
       vim.schedule(function()
         notify.notify(m, l, o)
       end)

--- a/tests/unit/init_spec.lua
+++ b/tests/unit/init_spec.lua
@@ -62,6 +62,8 @@ describe("checking public interface", function()
       it("inherits options", function()
         local orig = notify("first", "info", { title = "test", icon = "x" })
         local next = notify("second", nil, { replace = orig })
+        assert.Not.Nil(orig)
+        assert.Not.Nil(next)
 
         assert.are.same(
           next,
@@ -71,6 +73,7 @@ describe("checking public interface", function()
 
       a.it("uses same window", function()
         local orig = async_notify("first", "info", { timeout = false })
+        assert.Not.Nil(orig)
         local win = orig.events.open()
         async_notify("second", nil, { replace = orig, timeout = 100 })
         async.util.scheduler()


### PR DESCRIPTION
The `vim_starting` workaround in #209 makes test failing, because
`notify(...)` no longers return any value when `vim.schedule`-ed.
In the headless mode (under which plenary unit tests are running),
we do not need to defer the execution. This should fix all the tests
that were failing.
