### PR TITLE
fix(#189): correct the top-bottom slot limits

### DIFF
--- a/lua/notify/stages/util.lua
+++ b/lua/notify/stages/util.lua
@@ -85,9 +85,9 @@ local function window_intervals(windows, direction, cmp)
 end
 
 function M.get_slot_range(direction)
-  local top = vim.opt.tabline:get() == "" and 0 or 1
+  local top = vim.opt.showtabline:get() == 0 and 0 or 1
   local bottom = vim.opt.lines:get()
-    - (vim.opt.cmdheight:get() + (vim.opt.laststatus:get() > 0 and 1 or 0))
+    - (vim.opt.cmdheight:get() + (vim.opt.laststatus:get() > 0 and 1 or 0) + 1)
   local left = 1
   local right = vim.opt.columns:get()
   if M.DIRECTION.TOP_DOWN == direction then

--- a/lua/notify/stages/util.lua
+++ b/lua/notify/stages/util.lua
@@ -86,6 +86,10 @@ end
 
 function M.get_slot_range(direction)
   local top = vim.opt.showtabline:get() == 0 and 0 or 1
+  if vim.wo.winbar then
+    top = top + 1
+  end
+
   local bottom = vim.opt.lines:get()
     - (vim.opt.cmdheight:get() + (vim.opt.laststatus:get() > 0 and 1 or 0) + 1)
   local left = 1
@@ -168,7 +172,7 @@ function M.slot_after_previous(win, open_windows, direction)
     return move_slot(
       direction,
       start,
-      cur_win_conf[space_key(direction)] + border_padding(direction, cur_win_conf)
+      cur_win_conf[space_key(direction)] + border_padding(direction, cur_win_conf) / 2
     )
   end
 


### PR DESCRIPTION
Old implementation does not work properly because it -
1. overlaps the global statusline (off by 1 row), bottom limit
2. uses `tabline` option instead of `showtabline`, top limit