### PR TITLE
feat: add `no_animation` style

### DIFF
--- a/lua/notify/stages/no_animation.lua
+++ b/lua/notify/stages/no_animation.lua
@@ -1,0 +1,30 @@
+local stages_util = require("notify.stages.util")
+
+return function(direction)
+  return {
+    function(state)
+      local next_height = state.message.height + 2
+      local next_row = stages_util.available_slot(state.open_windows, next_height, direction)
+      if not next_row then
+        return nil
+      end
+      return {
+        relative = "editor",
+        anchor = "NE",
+        width = state.message.width,
+        height = state.message.height,
+        col = vim.opt.columns:get(),
+        row = next_row,
+        border = "rounded",
+        style = "minimal",
+      }
+    end,
+    function(state, win)
+      return {
+        col = vim.opt.columns:get(),
+        time = true,
+        row = stages_util.slot_after_previous(win, state.open_windows, direction),
+      }
+    end,
+  }
+end


### PR DESCRIPTION
This style has no animations (similarly as `static`), but after any notification dissapears, the rest adjust their positions (fall up/down as in `fade_in_slide_out`).

_Not sure about the naming of the style, I am open to other suggestions._