### PR TITLE
fix: only warn for termguicolors if version minor < 10

### DIFF
--- a/lua/notify/config/init.lua
+++ b/lua/notify/config/init.lua
@@ -183,7 +183,7 @@ function Config.setup(custom_config)
   local needs_opacity =
     vim.tbl_contains({ BUILTIN_STAGES.FADE_IN_SLIDE_OUT, BUILTIN_STAGES.FADE }, stages)
 
-  if needs_opacity and not vim.opt.termguicolors:get() then
+  if needs_opacity and not vim.opt.termguicolors:get() and vim.version().minor < 10 then
     user_config.stages = BUILTIN_STAGES.STATIC
     vim.schedule(function()
       vim.notify(


### PR DESCRIPTION
Neovim now sets termguicolors default to true if the terminal supports it. However, the option is not set until VimEnter, and this means that reading the value of termguicolors will always be false if the user has not set it in their config.

After I removed the unnecessary default option after updating neovim, I always get the warning now.

Check the version as well before warning since termguicolors is now set to true by default if the terminal supports it