### PR TITLE
feat(wrapped-compact): turn `[plugin-name]` prefixes into title

### DIFF
--- a/lua/notify/render/wrapped-compact.lua
+++ b/lua/notify/render/wrapped-compact.lua
@@ -44,17 +44,26 @@ return function(bufnr, notif, highlights, config)
   local title = notif.title[1]
   local prefix
 
+  local default_titles = { "Error", "Warning", "Notify" }
+  local has_valid_manual_title = type(title) == "string"
+    and #title > 0
+    and not vim.tbl_contains(default_titles, title)
+
+  -- If message has a `[plugin-name]` prefix but has no title, remove the prefix
+  -- and use it as title instead.
+  local pseudo_title = notif.message[1]:match("^%[.-%] ?")
+  if pseudo_title and not has_valid_manual_title then
+    notif.message[1] = notif.message[1]:sub(#pseudo_title + 1)
+    title = vim.trim(pseudo_title):sub(2, -2)
+    has_valid_manual_title = true
+  end
+
   -- wrap the text & add spacing
   local max_width = config.max_width()
   if max_width == nil then
     max_width = 80
   end
   local message = custom_wrap(notif.message, max_width)
-
-  local default_titles = { "Error", "Warning", "Notify" }
-  local has_valid_manual_title = type(title) == "string"
-    and #title > 0
-    and not vim.tbl_contains(default_titles, title)
 
   if has_valid_manual_title then
     -- has title = icon + title as header row


### PR DESCRIPTION
A lot of plugins prefix the messages with `[plugin-name]`, instead of using `title = plugin-name`. This results in inconsistent looks for notifications. This PR adds a small change that turns such prefixes into a notification title for nicer and more consistent notifications.

```lua
vim.notify("[foobar] hello world")
```

before:
<img alt="Showcase" width=70% src="https://github.com/rcarriga/nvim-notify/assets/73286100/3dee5044-849c-4099-84be-3df67ac6cf74">

after:
<img alt="Showcase" width=50% src="https://github.com/rcarriga/nvim-notify/assets/73286100/322354b9-71b8-41f2-8e70-ea4a13054213">

---

This PR only adds the change to `wrapped-compact`, but it's potentially also worth a thought whether this behavior could be implemented for nvim-notify in general.