### PR TITLE
fix: improve string width calculation

### DIFF
--- a/lua/notify/render/compact.lua
+++ b/lua/notify/render/compact.lua
@@ -15,8 +15,8 @@ return function(bufnr, notif, highlights)
 
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, notif.message)
 
-  local icon_length = vim.str_utfindex(icon)
-  local prefix_length = vim.str_utfindex(prefix)
+  local icon_length = #icon
+  local prefix_length = #prefix
 
   vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, 0, {
     hl_group = highlights.icon,

--- a/lua/notify/render/default.lua
+++ b/lua/notify/render/default.lua
@@ -3,14 +3,14 @@ local base = require("notify.render.base")
 
 return function(bufnr, notif, highlights, config)
   local left_icon = notif.icon .. " "
-  local max_message_width = math.max(math.max(unpack(vim.tbl_map(function(line)
-    return vim.fn.strchars(line)
-  end, notif.message))))
+  local max_message_width = math.max(unpack(vim.tbl_map(function(line)
+    return vim.api.nvim_strwidth(line)
+  end, notif.message)))
   local right_title = notif.title[2]
   local left_title = notif.title[1]
-  local title_accum = vim.str_utfindex(left_icon)
-    + vim.str_utfindex(right_title)
-    + vim.str_utfindex(left_title)
+  local title_accum = vim.api.nvim_strwidth(left_icon)
+    + vim.api.nvim_strwidth(right_title)
+    + vim.api.nvim_strwidth(left_title)
 
   local left_buffer = string.rep(" ", math.max(0, max_message_width - title_accum))
 
@@ -35,7 +35,7 @@ return function(bufnr, notif, highlights, config)
       {
         string.rep(
           "━",
-          math.max(vim.str_utfindex(left_buffer) + title_accum + 2, config.minimum_width())
+          math.max(vim.api.nvim_strwidth(left_buffer) + title_accum + 2, config.minimum_width())
         ),
         highlights.border,
       },

--- a/lua/notify/render/simple.lua
+++ b/lua/notify/render/simple.lua
@@ -2,11 +2,11 @@ local api = vim.api
 local base = require("notify.render.base")
 
 return function(bufnr, notif, highlights, config)
-  local max_message_width = math.max(math.max(unpack(vim.tbl_map(function(line)
-    return vim.fn.strchars(line)
-  end, notif.message))))
+  local max_message_width = math.max(unpack(vim.tbl_map(function(line)
+    return vim.api.nvim_strwidth(line)
+  end, notif.message)))
   local title = notif.title[1]
-  local title_accum = vim.str_utfindex(title)
+  local title_accum = vim.api.nvim_strwidth(title)
 
   local title_buffer = string.rep(
     " ",

--- a/lua/notify/render/wrapped-compact.lua
+++ b/lua/notify/render/wrapped-compact.lua
@@ -68,8 +68,8 @@ return function(bufnr, notif, highlights, config)
 
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, message)
 
-  local icon_length = vim.str_utfindex(icon)
-  local prefix_length = vim.str_utfindex(prefix) + 1
+  local icon_length = #icon
+  local prefix_length = #prefix + 1
 
   vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, 0, {
     hl_group = highlights.icon,

--- a/lua/notify/service/buffer/init.lua
+++ b/lua/notify/service/buffer/init.lua
@@ -111,7 +111,7 @@ function NotificationBuf:render()
   local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
   local width = self._config.minimum_width()
   for _, line in pairs(lines) do
-    width = math.max(width, vim.str_utfindex(line))
+    width = math.max(width, vim.api.nvim_strwidth(line))
   end
   local success, extmarks =
     pcall(api.nvim_buf_get_extmarks, buf, render_namespace, 0, #lines, { details = true })
@@ -126,7 +126,7 @@ function NotificationBuf:render()
     end
   end
   for _, text in pairs(virt_texts) do
-    width = math.max(width, vim.str_utfindex(text))
+    width = math.max(width, vim.api.nvim_strwidth(text))
   end
 
   self._width = width

--- a/tests/unit/init_spec.lua
+++ b/tests/unit/init_spec.lua
@@ -157,4 +157,43 @@ describe("checking public interface", function()
     a.util.scheduler()
     assert(vim.api.nvim_win_is_valid(win))
   end)
+
+  describe("notification width", function()
+    a.it("handles multibyte characters correctly", function()
+      local instance = notify.instance({
+        background_colour = "#000000",
+        minimum_width = 1,
+        render = "minimal",
+      }, false)
+      local win = instance.async("\u{1D4AF}\u{212F}\u{1D4C8}\u{1D4C9}").events.open() -- "𝒯ℯ𝓈𝓉"
+      assert.equal(4, vim.api.nvim_win_get_width(win))
+    end)
+
+    a.it("handles combining character sequences correctly", function()
+      local instance = notify.instance({
+        background_colour = "#000000",
+        minimum_width = 1,
+        render = "minimal",
+      }, false)
+      local win = instance
+        .async(
+          "T\u{0336}\u{0311}\u{0349}"
+            .. "e\u{0336}\u{030E}\u{0332}"
+            .. "s\u{0334}\u{0301}\u{0329}"
+            .. "t\u{0337}\u{0301}\u{031C}" -- "T̶͉̑e̶̲̎ś̴̩t̷̜́"
+        ).events
+        .open()
+      assert.equal(4, vim.api.nvim_win_get_width(win))
+    end)
+
+    a.it("respects East Asian Width Class", function()
+      local instance = notify.instance({
+        background_colour = "#000000",
+        minimum_width = 1,
+        render = "minimal",
+      }, false)
+      local win = instance.async("\u{FF34}\u{FF45}\u{FF53}\u{FF54}").events.open() -- "Ｔｅｓｔ"
+      assert.equal(8, vim.api.nvim_win_get_width(win))
+    end)
+  end)
 end)


### PR DESCRIPTION
I found that sometimes notifications are not rendered correctly. Here is an example:

```lua
local notify = require("notify")
local title = "\u{1D4AF}\u{212F}\u{1D4C8}\u{1D4C9}" -- "𝒯ℯ𝓈𝓉"

notify("Title not correctly highlighted", nil, { title = title, render = "compact" })
notify("Borderline too short", nil, { title = title, render = "simple" })
```
<img width="700" alt="notifications" src="https://github.com/rcarriga/nvim-notify/assets/90523111/884c452f-8ffe-411e-9dcf-c1a1c7060e05">

Such glitches can be caused by several factors: UTF-16 surrogate pairs (accidentally taken into account [here](https://github.com/rcarriga/nvim-notify/blob/80b67b265530632505193553d05127ae7fe09ddd/lua/notify/service/buffer/init.lua#L114) and [here](https://github.com/rcarriga/nvim-notify/blob/80b67b265530632505193553d05127ae7fe09ddd/lua/notify/service/buffer/init.lua#L129)), [combining character sequences](https://www.unicode.org/glossary/#combining_character_sequence), [fullwidth characters](https://www.unicode.org/glossary/#fullwidth), etc.

To fix the problem, this PR makes the following changes:

- Use Lua's `#` operator to determine the position of extmarks, as it requires simply byte indices.
- Use [`vim.api.nvim_strwidth`](https://neovim.io/doc/user/api.html#nvim_strwidth()) instead of `vim.fn.strchars` or `vim.str_utfindex` to more reliably calculate the width of a string on screen.

Tested with NeoVim `v0.5.1` and `v0.10.0-nightly`.

### Limitations

`vim.api.nvim_strwidth` works well in many cases, but is not perfect (e.g., for emojis).