### PR TITLE
feat: Add ability to clear notification history

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,18 @@ You can get a list of past notifications with the history function
 require("notify").history()
 ```
 
+There is another command to clear the history.
+
+```vim
+:NotificationsClear
+```
+
+You can clear the notifications with the clear history function
+
+```lua
+require("notify").clear_history()
+```
+
 ## Configuration
 
 ### Setup

--- a/lua/notify/init.lua
+++ b/lua/notify/init.lua
@@ -23,6 +23,7 @@ function notify.setup(user_config)
     require("telescope").load_extension("notify")
   end
   vim.cmd([[command! Notifications :lua require("notify")._print_history()<CR>]])
+  vim.cmd([[command! NotificationsClear :lua require("notify").clear_history()<CR>]])
 end
 
 function notify._config()
@@ -109,6 +110,16 @@ end
 
 ---@class notify.HistoryOpts
 ---@field include_hidden boolean Include notifications hidden from history
+
+--- Clear records of all previous notifications
+---
+--- You can use the `:NotificationsClear` command to clear the log of previous notifications
+function notify.clear_history()
+  if not global_instance then
+    notify.setup()
+  end
+  return global_instance.clear_history()
+end
 
 --- Dismiss all notification windows currently displayed
 ---@param opts notify.DismissOpts

--- a/lua/notify/instance.lua
+++ b/lua/notify/instance.lua
@@ -154,6 +154,10 @@ return function(user_config, inherit, global_config)
     return service and service:pending() or {}
   end
 
+  function instance.clear_history()
+    notifications = {}
+  end
+
   setmetatable(instance, {
     __call = function(_, m, l, o)
       if vim.in_fast_event() then


### PR DESCRIPTION
## Summary

Adds the `:NotificationsClear` user command and the `require("notify").clear_history()` lua function to clear notification history.

## Details

The implementation simply resets the internal notification history table to an empty table. I am not sure how this interacts with any potential asynchronous activity, but I figured that if something is waiting to be pushed into the history table, it doesn't really matter for practical purposes if it gets pushed before or after the table is reset.

I added a documentation header in the code and I updated the readme to reflect the new command and new function.

## Notes

Closes #158 