### PR TITLE
fix: fix "attempt to index a number value" issue

### DIFF
--- a/lua/notify/stages/util.lua
+++ b/lua/notify/stages/util.lua
@@ -142,7 +142,7 @@ end
 function M.slot_after_previous(win, open_windows, direction)
   local key = slot_key(direction)
   local cmp = is_increasing(direction) and less or greater
-  local exists, cur_win_conf = pcall(vim.api.nvim_win_get_config, win)
+  local exists, cur_win_conf = pcall(M.get_win_config, win)
   if not exists then
     return 0
   end


### PR DESCRIPTION
`nvim_get_win_config` will return tables for `row`/`col` keys and trying to access them with `false`/`true` will throw an error.

utils already has a custom `get_win_config` that returns the same, but handles `row`/`col` and converts them to the expected type.

Been experiencing that a lot lately. I'm running neovim nightly btw

Fix #252 