### PR TITLE
fix(telescope): enable wrap on preview

### DIFF
--- a/lua/telescope/_extensions/notify.lua
+++ b/lua/telescope/_extensions/notify.lua
@@ -103,6 +103,7 @@ local telescope_notifications = function(opts)
         define_preview = function(self, entry, status)
           local notification = entry.value
           local max_width = vim.api.nvim_win_get_config(status.preview_win).width
+          vim.api.nvim_win_set_option(status.preview_win, "wrap", true)
           notify.open(notification, { buffer = self.state.bufnr, max_width = max_width })
         end,
       }),


### PR DESCRIPTION
# Summary
Addresses https://github.com/rcarriga/nvim-notify/issues/234 allowing notification text to wrap in the telescope preview window to accommodate its fixed width.
## Before
![image](https://github.com/rcarriga/nvim-notify/assets/50156421/962b4c96-605d-4ec9-9a02-44d6b1cd730d)
## After
![image](https://github.com/rcarriga/nvim-notify/assets/50156421/cbcb785e-cb05-4e4e-99e1-bc2d4630c2b6)
