### PR TITLE
fix: improve correctness of neovim version checking

### DIFF
--- a/lua/notify/config/init.lua
+++ b/lua/notify/config/init.lua
@@ -183,7 +183,7 @@ function Config.setup(custom_config)
   local needs_opacity =
     vim.tbl_contains({ BUILTIN_STAGES.FADE_IN_SLIDE_OUT, BUILTIN_STAGES.FADE }, stages)
 
-  if needs_opacity and not vim.opt.termguicolors:get() and vim.version().minor < 10 then
+  if needs_opacity and not vim.opt.termguicolors:get() and vim.fn.has("nvim-0.10") == 0 then
     user_config.stages = BUILTIN_STAGES.STATIC
     vim.schedule(function()
       vim.notify(


### PR DESCRIPTION
Checking only the minor version is not technically correct for this check. It probably won't be a big deal because 1.0 is quite a bit away, but this does protect against this.