### PR TITLE
feat: `wrapped-compact` uses nvim 0.10's inline text for proper padding

### DIFF
--- a/lua/notify/render/wrapped-compact.lua
+++ b/lua/notify/render/wrapped-compact.lua
@@ -20,12 +20,12 @@ end
 ---@param max_width number
 ---@return string[]
 local function custom_wrap(lines, max_width)
-  local rightPad = "  "
+  local right_pad = "  "
   local wrapped_lines = {}
   for _, line in pairs(lines) do
-    local new_lines = split_length(line, max_width - #rightPad)
+    local new_lines = split_length(line, max_width - #right_pad)
     for _, nl in ipairs(new_lines) do
-      table.insert(wrapped_lines, nl:gsub("^%s+", "") .. rightPad)
+      table.insert(wrapped_lines, nl:gsub("^%s+", "") .. right_pad)
     end
   end
   return wrapped_lines
@@ -49,7 +49,7 @@ return function(bufnr, notif, highlights, config)
     and not vim.tbl_contains(default_titles, title)
 
   if has_valid_manual_title then
-    prefix = string.format("%s %s", icon, title)
+    prefix = string.format("%s %s ", icon, title)
     prefix_length = vim.str_utfindex(prefix) + 2
     table.insert(message, 1, prefix)
   end

--- a/lua/notify/render/wrapped-compact.lua
+++ b/lua/notify/render/wrapped-compact.lua
@@ -1,7 +1,4 @@
--- alternative compact renderer for nvim-notify.
--- Wraps text and adds some padding (only really to the left, since padding to
--- the right is somehow not display correctly).
--- Modified version of https://github.com/rcarriga/nvim-notify/blob/master/lua/notify/render/compact.lua
+-- WRAPS TEXT AND ADDS SOME PADDING.
 --------------------------------------------------------------------------------
 
 ---@param line string
@@ -14,7 +11,7 @@ local function split_length(line, width)
     if #line == 0 then
       return text
     end
-    next_line, line = line:sub(1, width), line:sub(width)
+    next_line, line = line:sub(1, width), line:sub(width + 1)
     text[#text + 1] = next_line
   end
 end
@@ -23,12 +20,12 @@ end
 ---@param max_width number
 ---@return string[]
 local function custom_wrap(lines, max_width)
+  local rightPad = "  "
   local wrapped_lines = {}
   for _, line in pairs(lines) do
-    local new_lines = split_length(line, max_width)
+    local new_lines = split_length(line, max_width - #rightPad)
     for _, nl in ipairs(new_lines) do
-      nl = nl:gsub("^%s*", " "):gsub("%s*$", " ") -- ensure padding
-      table.insert(wrapped_lines, nl)
+      table.insert(wrapped_lines, nl:gsub("^%s+", "") .. rightPad)
     end
   end
   return wrapped_lines
@@ -41,49 +38,52 @@ end
 return function(bufnr, notif, highlights, config)
   local namespace = require("notify.render.base").namespace()
   local icon = notif.icon
+  local icon_length = vim.str_utfindex(icon)
+  local prefix = ""
+  local prefix_length = 0
+  local message = custom_wrap(notif.message, config.max_width() or 80)
   local title = notif.title[1]
-  local prefix
-
-  -- wrap the text & add spacing
-  local max_width = config.max_width()
-  if max_width == nil then
-    max_width = 80
-  end
-  local message = custom_wrap(notif.message, max_width)
-
   local default_titles = { "Error", "Warning", "Notify" }
   local has_valid_manual_title = type(title) == "string"
     and #title > 0
     and not vim.tbl_contains(default_titles, title)
 
   if has_valid_manual_title then
-    -- has title = icon + title as header row
-    prefix = string.format(" %s %s", icon, title)
+    prefix = string.format("%s %s", icon, title)
+    prefix_length = vim.str_utfindex(prefix) + 2
     table.insert(message, 1, prefix)
-  else
-    -- no title = prefix the icon
-    prefix = string.format(" %s", icon)
-    message[1] = string.format("%s %s", prefix, message[1])
   end
 
+  message[1] = " " .. message[1]
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, message)
 
-  local icon_length = vim.str_utfindex(icon)
-  local prefix_length = vim.str_utfindex(prefix) + 1
-
-  vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, 0, {
-    hl_group = highlights.icon,
-    end_col = icon_length + 1,
-    priority = 50,
-  })
-  vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, icon_length + 1, {
-    hl_group = highlights.title,
-    end_col = prefix_length + 1,
-    priority = 50,
-  })
+  if has_valid_manual_title then
+    vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, 0, {
+      hl_group = highlights.icon,
+      end_col = icon_length + 1,
+      priority = 50,
+    })
+    vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, icon_length + 1, {
+      hl_group = highlights.title,
+      end_col = prefix_length + 1,
+      priority = 50,
+    })
+  end
   vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, prefix_length + 1, {
     hl_group = highlights.body,
     end_line = #message,
     priority = 50,
   })
+
+  -- padding to the left/right
+  for ln = 1, #message do
+    vim.api.nvim_buf_set_extmark(bufnr, namespace, ln, 0, {
+      virt_text = { { " ", highlights.body } },
+      virt_text_pos = "inline",
+    })
+    vim.api.nvim_buf_set_extmark(bufnr, namespace, ln, 0, {
+      virt_text = { { " ", highlights.body } },
+      virt_text_pos = "right_align",
+    })
+  end
 end


### PR DESCRIPTION
Now uses nvim inline text to properly create padding. While I was at it, simplified the code a bit and also fixed two cases where some characters get cut off (notice in the first line of the first before image, the `fugiat` missing the `fug`).

before:

<img alt="Showcase" width=70% src="https://github.com/rcarriga/nvim-notify/assets/73286100/7646117e-9e09-4aeb-ad40-21c1061fd9bf">

after:

<img alt="Showcase" width=70% src="https://github.com/rcarriga/nvim-notify/assets/73286100/242d31d3-9b1d-48aa-a0cc-ed475b822fb5">

code to test:
```lua
local msg = "Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit."

vim.notify(msg, vim.log.levels.INFO, {
	title = "Foobar",
	timeout = false,
})
vim.notify(msg, vim.log.levels.INFO, {
	timeout = false,
})
```