### PR TITLE
Merge duplicate notifications

### DIFF
--- a/lua/notify/config/init.lua
+++ b/lua/notify/config/init.lua
@@ -30,6 +30,7 @@ local default_config = {
   minimum_width = 50,
   fps = 30,
   top_down = true,
+  merge_duplicates = true,
   time_formats = {
     notification_history = "%FT%T",
     notification = "%T",
@@ -58,6 +59,7 @@ local default_config = {
 ---@field minimum_width integer Minimum width for notification windows
 ---@field fps integer Frames per second for animation stages, higher value means smoother animations but more CPU usage
 ---@field top_down boolean whether or not to position the notifications at the top or not
+---@field merge_duplicates boolean|integer whether to replace visible notification if new one is the same, can be an integer for min duplicate count
 
 local opacity_warned = false
 
@@ -154,6 +156,10 @@ function Config.setup(custom_config)
 
   function config.top_down()
     return user_config.top_down
+  end
+
+  function config.merge_duplicates()
+    return user_config.merge_duplicates
   end
 
   function config.on_close()

--- a/lua/notify/render/compact.lua
+++ b/lua/notify/render/compact.lua
@@ -11,9 +11,12 @@ return function(bufnr, notif, highlights)
   else
     prefix = string.format("%s |", icon)
   end
-  notif.message[1] = string.format("%s %s", prefix, notif.message[1])
+  local message = {
+    string.format("%s %s", prefix, notif.message[1]),
+    unpack(notif.message, 2)
+  }
 
-  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, notif.message)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, message)
 
   local icon_length = vim.str_utfindex(icon)
   local prefix_length = vim.str_utfindex(prefix)
@@ -30,7 +33,8 @@ return function(bufnr, notif, highlights)
   })
   vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, prefix_length + 1, {
     hl_group = highlights.body,
-    end_line = #notif.message,
+    end_line = #message,
     priority = 50,
   })
 end
+

--- a/lua/notify/render/compact.lua
+++ b/lua/notify/render/compact.lua
@@ -5,6 +5,10 @@ return function(bufnr, notif, highlights)
   local icon = notif.icon
   local title = notif.title[1]
 
+  if type(title) == "string" and notif.duplicates then
+    title = string.format('%s x%d', title, #notif.duplicates)
+  end
+
   local prefix
   if type(title) == "string" and #title > 0 then
     prefix = string.format("%s | %s:", icon, title)
@@ -37,4 +41,3 @@ return function(bufnr, notif, highlights)
     priority = 50,
   })
 end
-

--- a/lua/notify/render/default.lua
+++ b/lua/notify/render/default.lua
@@ -8,6 +8,9 @@ return function(bufnr, notif, highlights, config)
   end, notif.message))))
   local right_title = notif.title[2]
   local left_title = notif.title[1]
+  if notif.duplicates then
+    left_title = string.format('%s (x%d)', left_title, #notif.duplicates)
+  end
   local title_accum = vim.str_utfindex(left_icon)
     + vim.str_utfindex(right_title)
     + vim.str_utfindex(left_title)

--- a/lua/notify/render/minimal.lua
+++ b/lua/notify/render/minimal.lua
@@ -2,13 +2,21 @@ local api = vim.api
 local base = require("notify.render.base")
 
 return function(bufnr, notif, highlights)
+  local message = notif.message
+  if notif.duplicates then
+    message = {
+      string.format("x%d %s", #notif.duplicates, notif.message[1]),
+      unpack(notif.message, 2)
+    }
+  end
+
   local namespace = base.namespace()
-  api.nvim_buf_set_lines(bufnr, 0, -1, false, notif.message)
+  api.nvim_buf_set_lines(bufnr, 0, -1, false, message)
 
   api.nvim_buf_set_extmark(bufnr, namespace, 0, 0, {
     hl_group = highlights.icon,
-    end_line = #notif.message - 1,
-    end_col = #notif.message[#notif.message],
+    end_line = #message - 1,
+    end_col = #message[#message],
     priority = 50,
   })
 end

--- a/lua/notify/render/simple.lua
+++ b/lua/notify/render/simple.lua
@@ -6,6 +6,9 @@ return function(bufnr, notif, highlights, config)
     return vim.fn.strchars(line)
   end, notif.message))))
   local title = notif.title[1]
+  if notif.duplicates then
+    title = string.format('%s (x%d)', title, #notif.duplicates)
+  end
   local title_accum = vim.str_utfindex(title)
 
   local title_buffer = string.rep(

--- a/lua/notify/render/wrapped-compact.lua
+++ b/lua/notify/render/wrapped-compact.lua
@@ -59,10 +59,16 @@ return function(bufnr, notif, highlights, config)
   if has_valid_manual_title then
     -- has title = icon + title as header row
     prefix = string.format(" %s %s", icon, title)
+    if notif.duplicates then
+      prefix = string.format('%s x%d', prefix, #notif.duplicates)
+    end
     table.insert(message, 1, prefix)
   else
     -- no title = prefix the icon
     prefix = string.format(" %s", icon)
+    if notif.duplicates then
+      prefix = string.format('%s x%d', prefix, #notif.duplicates)
+    end
     message[1] = string.format("%s %s", prefix, message[1])
   end
 

--- a/lua/notify/service/notification.lua
+++ b/lua/notify/service/notification.lua
@@ -13,6 +13,7 @@
 ---@field on_open fun(win: number, record: notify.Record) | nil
 ---@field on_close fun(win: number, record: notify.Record) | nil
 ---@field render fun(buf: integer, notification: notify.Notification, highlights: table<string, string>)
+---@field duplicates? integer[] shared list of duplicate notifications by id
 local Notification = {}
 
 local level_maps = vim.tbl_extend("keep", {}, vim.log.levels)
@@ -52,6 +53,7 @@ function Notification:new(id, message, level, opts, config)
     animate = opts.animate ~= false,
     render = opts.render,
     hide_from_history = opts.hide_from_history,
+    duplicates = opts.duplicates,
   }
   self.__index = self
   setmetatable(notif, self)

--- a/tests/manual/merge_duplicates.lua
+++ b/tests/manual/merge_duplicates.lua
@@ -1,0 +1,75 @@
+local function coroutine_resume()
+    local co = assert(coroutine.running())
+    return function(...)
+        local ret = { coroutine.resume(co, ...) }
+        -- Re-raise errors with correct traceback
+        local ok, err = unpack(ret)
+        if not ok then
+            error(debug.traceback(co, err))
+        end
+        return unpack(ret, 2)
+    end
+end
+
+local function coroutine_sleep()
+    local resume = coroutine_resume()
+    return function(ms)
+        vim.defer_fn(resume, ms)
+        coroutine.yield()
+    end
+end
+
+local function run()
+    local sleep = coroutine_sleep()
+
+    local countdown = function(seconds)
+        local id
+        for i = 1, seconds do
+            -- local msg = string.format('Will show once again in %d seconds', seconds - i + 1)
+            local msg = string.format('Will show once again in %d seconds', seconds - i + 1)
+            id = vim.notify(msg, vim.log.levels.WARN, { replace = id }).id
+            sleep(1000)
+        end
+    end
+
+    local texts = {
+        'AAA This is first text',
+        'BBBBBB Second text of duplicate notifications',
+        -- 'CCCCCCCCC Third text',
+    }
+
+    local show_all = function(level)
+        for _, text in ipairs(texts) do
+            vim.notify(text, level)
+            sleep(50)
+        end
+    end
+
+    show_all()
+
+    sleep(1000)
+    show_all()
+
+    sleep(1000)
+    show_all()
+
+    sleep(1000)
+    show_all(vim.log.levels.WARN)
+    sleep(1000)
+    show_all(vim.log.levels.WARN)
+
+    sleep(1000)
+    show_all()
+
+    -- wait until the previous notifications disappear
+    countdown(10)
+    show_all()
+
+    sleep(2000)
+    for _ = 1, 41 do
+        sleep(50)
+        show_all()
+    end
+end
+
+coroutine.wrap(run)()


### PR DESCRIPTION
Sometimes it happens that the same notification is displayed multiple times, usually due to some buggy callback. In such scenario, instead of displaying multiple duplicate notifications, they just replace the initial one. Renderers can use `#notif.duplicates` to display duplicates count. 

Specifying `merge_duplicates` as integer works as minimal duplicates count, but the way it is implemented right now may give somewhat unexpected result - it will replace only one of the previous notifications, but renderer will display total different duplicate counts on all, so overall duplicate count is not the sum of displayed ones. If this is unwanted then we may just remove option to use integer.

Example with the default renderer and `merge_duplicates = true`:

https://github.com/rcarriga/nvim-notify/assets/16623787/f3883bf1-7409-493d-993b-8111d4ca34a3