### PR TITLE
feat: add `wrapped-minimal` as renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,10 @@ Mostly same as `compact`, but lines are wrapped based on `max_width`, some paddi
 
 ![image](https://github.com/rcarriga/nvim-notify/assets/73286100/72237d45-6e3b-4c2a-8010-513a26871682)
 
+6. "wrapped-compact"
+
+Similar to `minimal`, but lines are wrapped based on `max_width`, some padding is added.
+
 Feel free to submit custom rendering functions to share with others!
 
 ### Animation Style

--- a/lua/notify/render/init.lua
+++ b/lua/notify/render/init.lua
@@ -12,6 +12,7 @@
 --- - `"simple"`
 --- - `"compact"`
 --- - `"wrapped-compact"`
+--- - `"wrapped-minimal"`
 ---
 --- Custom functions should accept a buffer, a notification record and a highlights table
 ---

--- a/lua/notify/render/wrapped-minimal.lua
+++ b/lua/notify/render/wrapped-minimal.lua
@@ -1,3 +1,4 @@
+-- PENDING https://github.com/rcarriga/nvim-notify/pull/280
 -- Like `minimal`, but wrapped.
 --------------------------------------------------------------------------------
 
@@ -36,8 +37,8 @@ end
 ---@param config notify.Config
 return function(bufnr, notif, highlights, config)
 	local namespace = require("notify.render.base").namespace()
-	local message = custom_wrap(notif.message, config.max_width() or 80)
-
+	local max_width = config.max_width() or 80
+	local message = custom_wrap(notif.message, max_width)
 	vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, message)
 
 	-- add padding to the left/right
@@ -45,10 +46,12 @@ return function(bufnr, notif, highlights, config)
 		vim.api.nvim_buf_set_extmark(bufnr, namespace, ln, 0, {
 			virt_text = { { " ", highlights.body } },
 			virt_text_pos = "inline",
+			priority = 50,
 		})
 		vim.api.nvim_buf_set_extmark(bufnr, namespace, ln, 0, {
 			virt_text = { { " ", highlights.body } },
 			virt_text_pos = "right_align",
+			priority = 50,
 		})
 	end
 end

--- a/lua/notify/render/wrapped-minimal.lua
+++ b/lua/notify/render/wrapped-minimal.lua
@@ -31,9 +31,9 @@ local function custom_wrap(lines, max_width)
 end
 
 ---@param bufnr number
----@param notif object
----@param highlights object
----@param config object plugin config_obj
+---@param notif notify.Record
+---@param highlights notify.Highlights
+---@param config notify.Config
 return function(bufnr, notif, highlights, config)
 	local namespace = require("notify.render.base").namespace()
 	local message = custom_wrap(notif.message, config.max_width() or 80)

--- a/lua/notify/render/wrapped-minimal.lua
+++ b/lua/notify/render/wrapped-minimal.lua
@@ -26,7 +26,7 @@ local function custom_wrap(lines, max_width)
 			table.insert(wrapped_lines, nl:gsub("^%s+", "") .. right_pad)
 		end
 	end
-	wrapped_lines[1] = " " .. wrapped_lines[1]
+	wrapped_lines[1] = " " .. (wrapped_lines[1] or "")
 	return wrapped_lines
 end
 
@@ -39,12 +39,6 @@ return function(bufnr, notif, highlights, config)
 	local message = custom_wrap(notif.message, config.max_width() or 80)
 
 	vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, message)
-
-	vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, 1, {
-		hl_group = highlights.body,
-		end_line = #message,
-		priority = 50,
-	})
 
 	-- add padding to the left/right
 	for ln = 1, #message do

--- a/lua/notify/render/wrapped-minimal.lua
+++ b/lua/notify/render/wrapped-minimal.lua
@@ -1,0 +1,60 @@
+-- Like `minimal`, but wrapped.
+--------------------------------------------------------------------------------
+
+---@param line string
+---@param width number
+---@return string[]
+local function split_length(line, width)
+	local text = {}
+	local next_line
+	while true do
+		if #line == 0 then return text end
+		next_line, line = line:sub(1, width), line:sub(width + 1)
+		text[#text + 1] = next_line
+	end
+end
+
+---@param lines string[]
+---@param max_width number
+---@return string[]
+local function custom_wrap(lines, max_width)
+	local right_pad = "  "
+	local wrapped_lines = {}
+	for _, line in pairs(lines) do
+		local new_lines = split_length(line, max_width - #right_pad)
+		for _, nl in ipairs(new_lines) do
+			table.insert(wrapped_lines, nl:gsub("^%s+", "") .. right_pad)
+		end
+	end
+	wrapped_lines[1] = " " .. wrapped_lines[1]
+	return wrapped_lines
+end
+
+---@param bufnr number
+---@param notif object
+---@param highlights object
+---@param config object plugin config_obj
+return function(bufnr, notif, highlights, config)
+	local namespace = require("notify.render.base").namespace()
+	local message = custom_wrap(notif.message, config.max_width() or 80)
+
+	vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, message)
+
+	vim.api.nvim_buf_set_extmark(bufnr, namespace, 0, 1, {
+		hl_group = highlights.body,
+		end_line = #message,
+		priority = 50,
+	})
+
+	-- add padding to the left/right
+	for ln = 1, #message do
+		vim.api.nvim_buf_set_extmark(bufnr, namespace, ln, 0, {
+			virt_text = { { " ", highlights.body } },
+			virt_text_pos = "inline",
+		})
+		vim.api.nvim_buf_set_extmark(bufnr, namespace, ln, 0, {
+			virt_text = { { " ", highlights.body } },
+			virt_text_pos = "right_align",
+		})
+	end
+end


### PR DESCRIPTION
Like `minimal`, but `wrapped`. 

I actually use it together with a window title in the border, but that cannot be added to the renderer, unfortunately (see #279).
![image](https://github.com/rcarriga/nvim-notify/assets/73286100/4a1faca9-8df5-49a6-ac08-db1ceed55671)
