### PR TITLE
feat: dynamic timeouts

### DIFF
--- a/lua/notify/config/init.lua
+++ b/lua/notify/config/init.lua
@@ -45,7 +45,7 @@ local default_config = {
 
 ---@class notify.Config
 ---@field level string|integer Minimum log level to display. See vim.log.levels.
----@field timeout number Default timeout for notification
+---@field timeout number|(fun(notification:notify.Notification):number) Default timeout for notification
 ---@field max_width number|function Max number of columns for messages
 ---@field max_height number|function Max number of lines for a message
 ---@field stages string|function[] Animation stages
@@ -144,8 +144,13 @@ function Config.setup(custom_config)
     return user_config.stages
   end
 
-  function config.default_timeout()
-    return user_config.timeout
+  ---@param notification notify.Notification
+  function config.timeout(notification)
+    if type(user_config.timeout) == "function" then
+      return user_config.timeout(notification)
+    else
+      return user_config.timeout
+    end
   end
 
   function config.on_open()

--- a/lua/notify/service/buffer/init.lua
+++ b/lua/notify/service/buffer/init.lua
@@ -134,7 +134,11 @@ function NotificationBuf:render()
 end
 
 function NotificationBuf:timeout()
-  return self._notif.timeout
+  if self._notif.timeout ~= nil and (type(self._notif.timeout) == "function") then
+    return self._notif.timeout(self._notif)
+  else
+    return self._notif.timeout
+  end
 end
 
 function NotificationBuf:buffer()

--- a/lua/notify/service/notification.lua
+++ b/lua/notify/service/notification.lua
@@ -2,7 +2,7 @@
 ---@field id integer
 ---@field level string
 ---@field message string[]
----@field timeout number | nil
+---@field timeout number | (fun(notification:notify.Notification):number) | nil
 ---@field title string[]
 ---@field icon string
 ---@field time number

--- a/lua/notify/windows/init.lua
+++ b/lua/notify/windows/init.lua
@@ -116,14 +116,16 @@ function WindowAnimator:on_refresh(win)
   if not notif_buf then
     return
   end
+
   if self.timers[win] then
-    self.timers[win]:set_repeat(notif_buf:timeout() or self.config.default_timeout())
+    self.timers[win]:set_repeat(notif_buf:timeout() or self.config.timeout(notif_buf._notif))
     self.timers[win]:again()
   end
 end
 
 function WindowAnimator:_start_timer(win)
-  local buf_time = self.notif_bufs[win]:timeout() == nil and self.config.default_timeout()
+  local buf_time = self.notif_bufs[win]:timeout() == nil
+      and self.config.timeout(self.notif_bufs[win]._notif)
     or self.notif_bufs[win]:timeout()
   if buf_time ~= false then
     if buf_time == true then


### PR DESCRIPTION
This change allows the timeout to be assigned to a function, which receives the notification itself, so that can be used to calculate the desired timeout (or chose to ignore it and calculate it based on other parameters).

I tested it with a function that estimates how long the message could take to be read:

```lua
local function estimateReadingTime(text)
	local words = {}
	for word in text:gmatch("%S+") do
		table.insert(words, word)
	end

	local wordCount = #words
	local averageReadingSpeed = 200 -- words per minute
	local minutesToRead = wordCount / averageReadingSpeed
	local millisecondsToRead = minutesToRead * 60 * 1000

	return math.floor(millisecondsToRead)
end

local function calculateTimeout(notification)
	local allText = table.concat(notification.title) .. " " .. table.concat(notification.message)
	local estimatedMs = estimateAdvancedReadingTime(allText)
	return estimatedMs
end
```

Which is then referenced in the configuration:

```lua
{
  timeout = calculateTimeout,
}
```

The estimation function was knocked together using LLM, but it seems to do ok. I was motivated to implement this change while I was trying to find the ideal timeout which could work for short notifications and ones that spans multiple paragraphs.