### PR TITLE
fix: Corrects copying options from existing notification for boolean values

### DIFF
--- a/lua/notify/instance.lua
+++ b/lua/notify/instance.lua
@@ -63,7 +63,9 @@ return function(user_config, inherit, global_config)
       message = message or existing.message
       level = level or existing.level
       for _, key in ipairs(notif_keys) do
-        opts[key] = opts[key] or existing[key]
+        if opts[key] == nil then
+          opts[key] = existing[key]
+        end
       end
     end
     opts.render = get_render(opts.render or instance_config.render())


### PR DESCRIPTION
First of all, nice plugin. And the replace existing feature makes it even better. I enjoyed integrating it into [rspec-integrated.nvim](https://github.com/melopilosyan/rspec-integrated.nvim/blob/main/lua/rspec/notif.lua).

So. To reproduce the bug, execute this snippet on the master.

```lua
local prev = require("notify")("Won't show up in history", "INFO", {
  title =  "Note",
  hide_from_history = true,
})
require("notify")("Should show up, but doesn't", nil, {
  replace = prev,
  hide_from_history = false,
})
```

Then run the `:Notifications` command and notice the empty history. Although the second one is told not to hide.