### PR TITLE
fix: Resizes notification window on replace

### DIFF
--- a/lua/notify/service/init.lua
+++ b/lua/notify/service/init.lua
@@ -86,6 +86,10 @@ function NotificationService:replace(id, notif)
       "&winhl",
       "Normal:" .. existing.highlights.body .. ",FloatBorder:" .. existing.highlights.border
     )
+
+    vim.api.nvim_win_set_width(win, existing:width())
+    vim.api.nvim_win_set_height(win, existing:height())
+
     self._animator:on_refresh(win)
   end
 end


### PR DESCRIPTION
The `message` parameter is also allowed to be a list of strings. Hence, compared to the previous message, it's viewport dimensions can change both horizontally and vertically.

This sets the existing window width & height to fit the new notification buffer.

---

To reproduce the issue, run this snippet on the master.
```lua
local prev = require("notify")("Somewhat long initial test message", "INFO", { title =  "Note" })
require("notify")({ "A multi line", "replacement" }, nil, { replace = prev })
```

Notice the notification body only contains the string "A multi line". The second "replacement" line is not visible.

![2024-10-03_22-48](https://github.com/user-attachments/assets/e9620dc7-3fca-4823-9a39-fda662872038)

And here's the expected result with this change:
![2024-10-03_22-51](https://github.com/user-attachments/assets/0525df93-b104-4366-b765-ab8c9810ecc5)

