### PR TITLE
perf: mitigate the cursor flickering issue

### DIFF
--- a/lua/notify/config/init.lua
+++ b/lua/notify/config/init.lua
@@ -71,8 +71,8 @@ local function validate_highlight(colour_or_group, needs_opacity)
     end
   end
   return function()
-    local group = vim.api.nvim_get_hl_by_name(colour_or_group, true)
-    if not group or not group.background then
+    local group = vim.api.nvim_get_hl(0, { name = colour_or_group, create = false, link = false })
+    if not group or not group.bg then
       if needs_opacity and not opacity_warned then
         opacity_warned = true
         vim.schedule(function()
@@ -88,14 +88,14 @@ Defaulting to #000000]], "warn", {
             title = "nvim-notify",
             on_open = function(win)
               local buf = vim.api.nvim_win_get_buf(win)
-              vim.api.nvim_buf_set_option(buf, "filetype", "markdown")
+              vim.api.nvim_set_option_value("filetype", "markdown", { buf = buf })
             end,
           })
         end)
       end
       return "#000000"
     end
-    return string.format("#%x", group.background)
+    return string.format("#%x", group.bg)
   end
 end
 

--- a/lua/notify/service/init.lua
+++ b/lua/notify/service/init.lua
@@ -55,12 +55,7 @@ function NotificationService:push(notif)
   self._pending:push(notif_buf)
   if not self._running then
     self:_run()
-  else
-    -- Forces a render during blocking events
-    -- https://github.com/rcarriga/nvim-notify/issues/5
-    pcall(self._animator.render, self._animator, self._pending, 1 / self._fps)
   end
-  vim.cmd("redraw")
   return buf
 end
 

--- a/lua/notify/windows/init.lua
+++ b/lua/notify/windows/init.lua
@@ -273,12 +273,11 @@ function WindowAnimator:_get_dimensions(notif_buf)
 end
 
 function WindowAnimator:_apply_win_state(win, win_state)
-  local win_updated = false
+  local hl_updated = false
   if win_state.opacity then
-    win_updated = true
     local notif_buf = self.notif_bufs[win]
     if notif_buf:is_valid() then
-      notif_buf.highlights:set_opacity(win_state.opacity.position)
+      hl_updated = notif_buf.highlights:set_opacity(win_state.opacity.position)
       vim.fn.setwinvar(
         win,
         "&winhl",
@@ -288,6 +287,7 @@ function WindowAnimator:_apply_win_state(win, win_state)
   end
   local exists, conf = util.get_win_config(win)
   local new_conf = {}
+  local win_updated = false
   if not exists then
     self:_remove_win(win)
   else
@@ -317,7 +317,9 @@ function WindowAnimator:_apply_win_state(win, win_state)
       api.nvim_win_set_config(win, new_conf)
     end
   end
-  return win_updated
+  -- The 'flush' key is set to enforce redrawing during blocking event.
+  vim.api.nvim__redraw({ win = win, valid = false, flush = true })
+  return hl_updated or win_updated
 end
 
 ---@return WindowAnimator


### PR DESCRIPTION
Instead of letting the `:hl` to redraw all things globally, use the `nvim__redraw` api to limit the redraw on the notification windows only. The api also handles the case of redrawing during blocking events by flushing the screen changes.

---

Mitigate the issues #56, #63 and #273.

After some investigation, it came down to two culprits:
1. The constant `:hl` commands (for fade in/out blending) that caused frequent global redraws.
2. Good amount of notification window resizing/repositioning.

This PR tickles the first one but couldn't fully eliminate the issue. In situations when the redraws are intense, e.g. many/fat notifications fade in/out around the same time, the problem can still occur. However, even in those situations, the flickering issue would disappear as soon as all the fade in/out are done. 

Side note: The flickering issue, at least for me, happened on Windows Terminal and WezTerm in Window. The nvim was run inside WSL. The flickering won't happen if I run WezTerm from WSL of VM. My theory is it is some throughput problem of the underneath ConPTY.

---

## Comparisons:

| Original | Mitigated |
| --------- | ---------- |
| <video src="https://github.com/user-attachments/assets/b30d15ee-c169-4b8f-bf54-24b5e3133102" /> | <video src="https://github.com/user-attachments/assets/6762f452-09ac-4033-b86d-0e5618b0a469" /> |
| <video src="https://github.com/user-attachments/assets/c885d95d-733d-4e82-89c6-feb9b568488b" /> | <video src="https://github.com/user-attachments/assets/949fef8a-ec6f-4e2e-9057-226abae1206a" /> |

---

## Additional Change

This commit also removes the work done by 414465468c93f693be4e2f69f47586cf37f3f751. I checked the original discussion the commit referred to but failed to see how the change could help. So if I understand it correctly the commit was trying to solve the issue of the notification window (animation) getting blocked during blocking events. The `redraw` command you added in the commit, however, is usually executed through the main loop path so it could only be executed once per new notification and wouldn't help the animation to advance further. Instead, since the recurring `WindowAnimator:_apply_win_state` is already running _outside of the main loop_ (because `NotificationService:_run` uses the deferring function), we could make use of it to just request a redraw with immediately flushing there to solve the blocking problem (tested with the `getchar` call followed immediately after a notification call).

This specific change does not contribute to the performance but I feel like somewhat related. If I misunderstood anything or you don't like this to be part of the commit, let me know :).