### PR TITLE
Add slide_out animation

### DIFF
--- a/lua/notify/config/init.lua
+++ b/lua/notify/config/init.lua
@@ -13,6 +13,7 @@ local BUILTIN_RENDERERS = {
 local BUILTIN_STAGES = {
   FADE = "fade",
   SLIDE = "slide",
+  SLIDE_OUT = "slide_out",
   FADE_IN_SLIDE_OUT = "fade_in_slide_out",
   STATIC = "static",
 }

--- a/lua/notify/stages/slide_out.lua
+++ b/lua/notify/stages/slide_out.lua
@@ -1,0 +1,50 @@
+local stages_util = require("notify.stages.util")
+
+return function(direction)
+  return {
+    function(state)
+      local next_height = state.message.height + 2
+      local next_row = stages_util.available_slot(state.open_windows, next_height, direction)
+      if not next_row then
+        return nil
+      end
+      return {
+        relative = "editor",
+        anchor = "NE",
+        width = state.message.width,
+        height = state.message.height,
+        col = vim.opt.columns:get(),
+        row = next_row,
+        border = "rounded",
+        style = "minimal",
+      }
+    end,
+    function(state, win)
+      return {
+        col = vim.opt.columns:get(),
+        time = true,
+        row = stages_util.slot_after_previous(win, state.open_windows, direction),
+      }
+    end,
+    function(state, win)
+      return {
+        width = {
+          1,
+          frequency = 2.5,
+          damping = 0.9,
+          complete = function(cur_width)
+            return cur_width < 3
+          end,
+        },
+        col = { vim.opt.columns:get() },
+        row = {
+          stages_util.slot_after_previous(win, state.open_windows, direction),
+          frequency = 3,
+          complete = function()
+            return true
+          end,
+        },
+      }
+    end,
+  }
+end


### PR DESCRIPTION
Hi! I needed an animation that shows the notification immediately so that `inputlist()` works. `inputlist()` expects synchroneous input, so nvim only has the chance to render the first frame of the notification animation. 

See https://github.com/folke/noice.nvim/issues/938

If the first frame is a transparent frame, I cannot see the prompt, so I decided to remove the first part of the `fade_in_slide_out` animation. I could have used `no_animation`, but this one looks nicer.