### PR TITLE
fix: remove unnecessary spaces when the icon is empty

### DIFF
--- a/lua/notify/render/default.lua
+++ b/lua/notify/render/default.lua
@@ -2,7 +2,7 @@ local api = vim.api
 local base = require("notify.render.base")
 
 return function(bufnr, notif, highlights, config)
-  local left_icon = notif.icon .. " "
+  local left_icon = notif.icon == "" and "" or notif.icon .. " "
   local max_message_width = math.max(math.max(unpack(vim.tbl_map(function(line)
     return vim.fn.strchars(line)
   end, notif.message))))
@@ -16,12 +16,11 @@ return function(bufnr, notif, highlights, config)
 
   local namespace = base.namespace()
   api.nvim_buf_set_lines(bufnr, 0, 1, false, { "", "" })
+
+  local virt_text = left_icon == "" and {} or { { " " }, { left_icon, highlights.icon } }
+  table.insert(virt_text, { left_title .. left_buffer, highlights.title })
   api.nvim_buf_set_extmark(bufnr, namespace, 0, 0, {
-    virt_text = {
-      { " " },
-      { left_icon, highlights.icon },
-      { left_title .. left_buffer, highlights.title },
-    },
+    virt_text = virt_text,
     virt_text_win_col = 0,
     priority = 10,
   })


### PR DESCRIPTION
## What

- Removing spaces around the icon from the title when the icon is empty.

## Motivation

I just want to disable icons, so I'm setting icons to be empty. For now, although we set icons to be empty, spaces for icons are still inserted into the title. Hence, it does not align with the title and the body.