### PR TITLE
fixed including an invalid parameter on highlights.lua (erased "create" parameter)

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,5 @@
+{
+    "diagnostics.globals": [
+        "vim"
+    ]
+}

--- a/lua/notify/service/buffer/highlights.lua
+++ b/lua/notify/service/buffer/highlights.lua
@@ -20,7 +20,7 @@ function NotifyBufHighlights:new(level, buffer, config)
     local new = orig .. buffer
 
     vim.api.nvim_set_hl(0, new, { link = orig })
-    local hl = vim.api.nvim_get_hl(0, { name = orig, create = false, link = false })
+    local hl = vim.api.nvim_get_hl(0, { name = orig, link = false })
     -- Removes the unwanted 'default' key, as we will copy the table for updating the highlight later.
     hl.default = nil
 


### PR DESCRIPTION
removed the parameter on nvim.api.nvim_get_hl('create' parameter) which is invalid