### PR TITLE
fix: priority type error for nvim 0.11

### DIFF
--- a/lua/notify/service/buffer/highlights.lua
+++ b/lua/notify/service/buffer/highlights.lua
@@ -122,7 +122,7 @@ function NotifyBufHighlights:_redefine_treesitter()
             hl_group = custom_hl,
             -- TODO: Not sure how neovim's highlighter doesn't have issues with overriding highlights
             -- Three marks on same region always show the second for some reason AFAICT
-            priority = metadata.priority or i + 200,
+            priority = tonumber(metadata.priority) or i + 200,
             conceal = metadata.conceal,
           })
         end


### PR DESCRIPTION
It seems like `metadata.priority` type is `string|integer` in nvim 0.11. This fixes the lua error. 