### PR TITLE
fix: disable cursorline, cursorcolumncolumn and NormalNC

### DIFF
--- a/lua/notify/service/init.lua
+++ b/lua/notify/service/init.lua
@@ -79,8 +79,10 @@ function NotificationService:replace(id, notif)
     vim.fn.setwinvar(
       win,
       "&winhl",
-      "Normal:" .. existing.highlights.body .. ",FloatBorder:" .. existing.highlights.border
+      "NormalNC:NONE" .. ",Normal:" .. existing.highlights.body .. ",FloatBorder:" .. existing.highlights.border
     )
+    vim.api.nvim_win_set_option(win, 'cursorcolumn', false)
+    vim.api.nvim_win_set_option(win, 'cursorline', false)
 
     vim.api.nvim_win_set_width(win, existing:width())
     vim.api.nvim_win_set_height(win, existing:height())

--- a/lua/notify/util/init.lua
+++ b/lua/notify/util/init.lua
@@ -85,7 +85,7 @@ function M.open_win(notif_buf, enter, opts)
   vim.fn.setwinvar(
     win,
     "&winhl",
-    "Normal:" .. notif_buf.highlights.body .. ",FloatBorder:" .. notif_buf.highlights.border
+    "NormalNC:NONE" .. ",Normal:" .. notif_buf.highlights.body .. ",FloatBorder:" .. notif_buf.highlights.border
   )
   vim.fn.setwinvar(win, "&wrap", 0)
   return win

--- a/lua/notify/windows/init.lua
+++ b/lua/notify/windows/init.lua
@@ -66,7 +66,7 @@ function WindowAnimator:push_pending(queue)
       vim.fn.setwinvar(
         win,
         "&winhl",
-        "Normal:" .. notif_buf.highlights.body .. ",FloatBorder:" .. notif_buf.highlights.border
+        "NormalNC:NONE" .. ",Normal:" .. notif_buf.highlights.body .. ",FloatBorder:" .. notif_buf.highlights.border
       )
       self.win_stages[win] = 2
       self.win_states[win] = {}
@@ -281,7 +281,7 @@ function WindowAnimator:_apply_win_state(win, win_state)
       vim.fn.setwinvar(
         win,
         "&winhl",
-        "Normal:" .. notif_buf.highlights.body .. ",FloatBorder:" .. notif_buf.highlights.border
+        "NormalNC:NONE" .. ",Normal:" .. notif_buf.highlights.body .. ",FloatBorder:" .. notif_buf.highlights.border
       )
     end
   end


### PR DESCRIPTION
People who use the `NormalNC` highlight group have notifications with that background. This makes the border look off. I think it makes sense to make notifications use the `Normal` highlight always, because we don't think of them as another active or innactive buffer even if they are.
Also, updated notifications can have `cursorline` and `cursorcolumn` enables. So once again it makes weird highlights.

I hope this gif comparison shows what I mean.
* Before
![before_patch](https://github.com/user-attachments/assets/0d939879-e461-4f4c-aaa2-ee7d12d62aec)
* After
![patched](https://github.com/user-attachments/assets/775d0c7d-5cf6-4d9b-b81f-a07c34c788ba)
