### PR TITLE
fix: update vim.validate usage

### DIFF
--- a/lua/notify/service/notification.lua
+++ b/lua/notify/service/notification.lua
@@ -34,11 +34,9 @@ function Notification:new(id, message, level, opts, config)
   if type(title) == "string" then
     title = { title, vim.fn.strftime(config.time_formats().notification, time) }
   end
-  vim.validate({
-    message = { message, "table" },
-    level = { level, "string" },
-    title = { title, "table" },
-  })
+  vim.validate('message', message, "table")
+  vim.validate('level', level, "string")
+  vim.validate('title', title, "table")
   local notif = {
     id = id,
     message = message,


### PR DESCRIPTION
The `vim.validate` function has deprecated one of its uses, which will be removed in neovim 1.0.

This updates the (sole?) use of vim.validate I could find. This was reported using nvim's |:checkhealth| command.